### PR TITLE
cocogitto for version and commit control

### DIFF
--- a/.github/workflows/cocogitto.yml
+++ b/.github/workflows/cocogitto.yml
@@ -17,3 +17,23 @@ jobs:
           check-latest-tag-only: true
           git-user: 'yoctoyotta1024'
           git-user-email: 'yoctoyotta1024@yahoo.com'
+
+  release:
+    needs: cog_check_job
+    # Only release new version when merging into `origin/main`.`
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'yoctoyotta1024'"
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Semver release
+        uses: cocogitto/cocogitto-action@v3
+        id: release
+        with:
+          release: true
+          git-user: 'yoctoyotta1024'
+          git-user-email: 'yoctoyotta1024@yahoo.com'
+
+      # The version number is accessible as a github action output
+      - name: Print version
+        run: "echo '${{ steps.release.outputs.version }}'"

--- a/.github/workflows/cocogitto.yml
+++ b/.github/workflows/cocogitto.yml
@@ -1,0 +1,21 @@
+name: cocogitto
+
+on: [pull_request]
+
+jobs:
+  cog_check_job:
+    runs-on: ubuntu-latest
+    name: check commits with cocogitto
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # pick the pr HEAD instead of the merge commit
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Conventional commits compliance check
+        uses: oknozor/cocogitto-action@v3
+        with:
+          check-latest-tag-only: true
+          git-user: 'yoctoyotta1024'
+          git-user-email: 'yoctoyotta1024@yahoo.com'

--- a/.github/workflows/cocogitto.yml
+++ b/.github/workflows/cocogitto.yml
@@ -1,6 +1,6 @@
 name: cocogitto
 
-on: [pull_request]
+on: [push]
 
 jobs:
   cog_check_job:
@@ -10,8 +10,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # pick the pr HEAD instead of the merge commit
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Conventional commits compliance check
         uses: oknozor/cocogitto-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
+- - -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 - - -
+
 ## [v0.1.0](https://github.com/yoctoyotta1024/microphysics_testcases/compare/1fa6a4a9c3c16909212ae18c289fc367ea9e608d..v0.1.0) - 2024-05-02
 #### Features
 - new changelog for repo - ([065e03e](https://github.com/yoctoyotta1024/microphysics_testcases/commit/065e03e87d5c26b89399c275ab34ed8cbd316fc9)) - clara.bayley
@@ -9,4 +10,3 @@ All notable changes to this project will be documented in this file. See [conven
 - new cog toml file for cocogitto - ([1fa6a4a](https://github.com/yoctoyotta1024/microphysics_testcases/commit/1fa6a4a9c3c16909212ae18c289fc367ea9e608d)) - clara.bayley
 
 - - -
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 - - -
+## [v0.1.1](https://github.com/yoctoyotta1024/microphysics_testcases/compare/2dab34dee899f70785c24ce97b45f3e5979a12d0..v0.1.1) - 2024-05-02
+#### Bug Fixes
+- manual versioning given X.Y.Z - ([3b38fac](https://github.com/yoctoyotta1024/microphysics_testcases/commit/3b38fac0c91b29a66fe2156ee9ade4a924681316)) - clara.bayley
+#### Miscellaneous Chores
+- whitespace - ([2dab34d](https://github.com/yoctoyotta1024/microphysics_testcases/commit/2dab34dee899f70785c24ce97b45f3e5979a12d0)) - clara.bayley
+
+- - -
+
 
 ## [v0.1.0](https://github.com/yoctoyotta1024/microphysics_testcases/compare/1fa6a4a9c3c16909212ae18c289fc367ea9e608d..v0.1.0) - 2024-05-02
 #### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 - - -
+## [v0.1.0](https://github.com/yoctoyotta1024/microphysics_testcases/compare/1fa6a4a9c3c16909212ae18c289fc367ea9e608d..v0.1.0) - 2024-05-02
+#### Features
+- new changelog for repo - ([065e03e](https://github.com/yoctoyotta1024/microphysics_testcases/commit/065e03e87d5c26b89399c275ab34ed8cbd316fc9)) - clara.bayley
+- add tag prefix 'v' and changelog settings to cog.toml - ([28c3aae](https://github.com/yoctoyotta1024/microphysics_testcases/commit/28c3aae5217173f07eec58ad062442e26ec1cda3)) - clara.bayley
+- cog ignores commits from merge requests - ([5917596](https://github.com/yoctoyotta1024/microphysics_testcases/commit/5917596e8f8aac048b53072bbc09a48a409f96b0)) - clara.bayley
+- new cog toml file for cocogitto - ([1fa6a4a](https://github.com/yoctoyotta1024/microphysics_testcases/commit/1fa6a4a9c3c16909212ae18c289fc367ea9e608d)) - clara.bayley
+
+- - -
+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,6 @@ authors:
   given-names: "Clara"
   orcid: "https://orcid.org/0000-0002-4540-9382"
 title: "A Good Science Project Template for Python and C++"
-version: 0.0.1
+version: X.Y.Z
 date-released: 27th February 2024
 url: "https://github.com/yoctoyotta1024/microphysics_testcases.git"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.18.0)
 project(project
   LANGUAGES CXX
   DESCRIPTION "Microphysics Test Cases by Clara Bayley and other developers"
-  VERSION 0.0.1
+  VERSION X.Y.Z
 )
 
 ## Use the pybind11 package from .gitmodules

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.18.0)
 project(project
   LANGUAGES CXX
   DESCRIPTION "Microphysics Test Cases by Clara Bayley and other developers"
-  VERSION X.Y.Z
 )
 
 ## Use the pybind11 package from .gitmodules

--- a/cog.toml
+++ b/cog.toml
@@ -1,5 +1,5 @@
 from_latest_tag = false
-ignore_merge_commits = false
+ignore_merge_commits = true
 disable_changelog = false
 disable_bump_commit = false
 generate_mono_repository_global_tag = true

--- a/cog.toml
+++ b/cog.toml
@@ -7,8 +7,15 @@ branch_whitelist = []
 skip_ci = "[skip ci]"
 skip_untracked = false
 tag_prefix = "v"
-pre_bump_hooks = []
-post_bump_hooks = []
+pre_bump_hooks = [
+    "echo {{version}}",
+]
+
+post_bump_hooks = [
+    "git push",
+    "git push origin {{version}}",
+]
+
 pre_package_bump_hooks = []
 post_package_bump_hooks = []
 

--- a/cog.toml
+++ b/cog.toml
@@ -6,6 +6,7 @@ generate_mono_repository_global_tag = true
 branch_whitelist = []
 skip_ci = "[skip ci]"
 skip_untracked = false
+tag_prefix = "v"
 pre_bump_hooks = []
 post_bump_hooks = []
 pre_package_bump_hooks = []
@@ -17,7 +18,11 @@ post_package_bump_hooks = []
 
 [changelog]
 path = "CHANGELOG.md"
-authors = []
+template = "remote"
+remote = "github.com"
+repository = "microphysics_testcases"
+owner = "yoctoyotta1024"
+authors = [{ username = "yoctoyotta1024", signature = "Clara Bayley" }]
 
 [bump_profiles]
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='Microphysics Test Cases',
-    version='0.0.1',
+    version='X.Y.Z',
     packages=find_packages(),
     install_requires=[
         'pytest',


### PR DESCRIPTION
CI using cocogitto to:
- cocogitto checks comits obey conventional commit specification upon pushes
- cocogitto updates changelog and makes new tag for releases upon pushes to main branch

note:
- version tags have 'v' prefix
- specification of commit standard on merge commits are ignored
- commits only since latest tag are checked
