### PR TITLE
thermodynamics uses arrays

### DIFF
--- a/libs/src_py/calcs.py
+++ b/libs/src_py/calcs.py
@@ -8,7 +8,7 @@ Created Date: Friday 1st March 2024
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Friday 1st March 2024
+Last Modified: Monday 17th June 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -19,7 +19,7 @@ functions for calculations of some quantities e.g. potential temperature(s)
 '''
 
 
-def dry_potential_temperature(temp, press):
+def dry_potential_temperature(temp, press, press0):
   r"""Calculate the potential temperature for dry air.
 
   This function calculates the potential temperature for dry air given the temperature and pressure.
@@ -45,6 +45,6 @@ def dry_potential_temperature(temp, press):
   cp_dry = 1004.64     # specific heat capacity of water vapour [J/Kg/K] (IAPWS97 at 273.15K)
   rgas_dry = rgas_univ / mr_dry   # specific gas constant for dry air [J/Kg/K] (approx. 287 J/Kg/K)
 
-  theta_dry = temp * (press[0] / press) ** (rgas_dry / cp_dry)
+  theta_dry = temp * (press0 / press) ** (rgas_dry / cp_dry)
 
   return theta_dry

--- a/libs/src_py/thermodynamics.py
+++ b/libs/src_py/thermodynamics.py
@@ -27,42 +27,42 @@ class Thermodynamics:
   content (mass mixing ratio) of vapour and condensates.
 
   Parameters:
-    temp (float):
+    temp (np.array):
       Temperature (K).
-    rho (float):
+    rho (np.array):
       Density of moist air (kg/m3).
-    press (float):
+    press (np.array):
       Pressure (Pa).
-    qvap (float):
+    qvap (np.array):
       Specific water vapor content (kg/kg).
-    qcond (float):
+    qcond (np.array):
       Specific cloud water content (kg/kg).
-    qice (float):
+    qice (np.array):
       Specific cloud ice content (kg/kg).
-    qrain (float):
+    qrain (np.array):
       Specific rain content (kg/kg).
-    qsnow (float):
+    qsnow (np.array):
       Specific snow content kg/kg).
-    qgrau (float):
+    qgrau (np.array):
       Specific graupel content (kg/kg).
 
   Attributes:
-    temp (float):
+    temp (np.array):
       Temperature (K).
-    rho (float):
+    rho (np.array):
       Density of moist air (kg/m3).
-    press (float):
+    press (np.array):
       Pressure (Pa).
     massmix_ratios (tuple):
       Specific content of vapour and condensates (see below).
 
     massmax_ratios consists of the following:
-            massmix_ratios[0] = qvap (float): Specific water vapor content (kg/kg)\n
-            massmix_ratios[1] = qcond (float): Specific cloud water content (kg/kg)\n
-            massmix_ratios[2] = qice (float): Specific cloud ice content (kg/kg)\n
-            massmix_ratios[3] = qrain (float): Specific rain content (kg/kg)\n
-            massmix_ratios[4] = qsnow (float): Specific snow content kg/kg)\n
-            massmix_ratios[5] = qgrau (float): Specific graupel content (kg/kg).
+            massmix_ratios[0] = qvap (np.array): Specific water vapor content (kg/kg)\n
+            massmix_ratios[1] = qcond (np.array): Specific cloud water content (kg/kg)\n
+            massmix_ratios[2] = qice (np.array): Specific cloud ice content (kg/kg)\n
+            massmix_ratios[3] = qrain (np.array): Specific rain content (kg/kg)\n
+            massmix_ratios[4] = qsnow (np.array): Specific snow content kg/kg)\n
+            massmix_ratios[5] = qgrau (np.array): Specific graupel content (kg/kg).
 
   '''
 

--- a/libs/src_py/thermodynamics.py
+++ b/libs/src_py/thermodynamics.py
@@ -8,7 +8,7 @@ Created Date: Wednesday 28th February 2024
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Friday 1st March 2024
+Last Modified: Monday 17th June 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -17,6 +17,7 @@ https://opensource.org/licenses/BSD-3-Clause
 File Description:
 '''
 
+import numpy as np
 
 class Thermodynamics:
   '''
@@ -65,19 +66,21 @@ class Thermodynamics:
 
   '''
 
-  def __init__(self, temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau):
+  def __init__(self, temp: np.ndarray, rho: np.ndarray, press: np.ndarray, qvap: np.ndarray,
+               qcond: np.ndarray, qice: np.ndarray, qrain: np.ndarray,
+               qsnow: np.ndarray, qgrau: np.ndarray):
     '''Initialize a thermodynamics object with the given variables
 
     Parameters:
-        press (float): Pressure (Pa).
-        temp (float): Temperature (K).
-        rho (float): Density of moist air (kg/m3)
-        qvap (float): Specific water vapor content (kg/kg)
-        qcond (float): Specific cloud water content (kg/kg)
-        qice (float): Specific cloud ice content (kg/kg)
-        qrain (float): Specific rain content (kg/kg)
-        qsnow (float): Specific snow content kg/kg)
-        qgrau (float): Specific graupel content (kg/kg)
+        press (np.array): Pressure (Pa).
+        temp (np.array): Temperature (K).
+        rho (np.array): Density of moist air (kg/m3)
+        qvap (np.array): Specific water vapor content (kg/kg)
+        qcond (np.array): Specific cloud water content (kg/kg)
+        qice (np.array): Specific cloud ice content (kg/kg)
+        qrain (np.array): Specific rain content (kg/kg)
+        qsnow (np.array): Specific snow content kg/kg)
+        qgrau (np.array): Specific graupel content (kg/kg)
 
     '''
     self.temp = temp

--- a/scripts/use_microphysics_scheme.py
+++ b/scripts/use_microphysics_scheme.py
@@ -8,7 +8,7 @@ Created Date: Tuesday 27th February 2024
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Thursday 29th February 2024
+Last Modified: Monday 17th June 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -31,8 +31,10 @@ from src_py.microphysics_scheme_wrapper import MicrophysicsSchemeWrapper
 def print_message(time, thermo):
   """Print statement about the time and some thermodynamic variables."""
 
-  msg = "time = {:.1f}s: ".format(time)
-  msg += "[T, rho, P] = [{:.2f}K, {:.3f}Kgm^-3, {:.0f}Pa]".format(thermo.temp, thermo.rho, thermo.press)
+  msg = "time = {:.1f}s:\n".format(time)
+  msg += "   T = "+str(["{:.2f}K".format(x) for x in thermo.temp])+",\n"
+  msg += " rho = "+str(["{:.3f}Kgm^-3".format(x) for x in thermo.rho])+",\n"
+  msg += "   P = "+str(["{:.0f}Pa".format(x) for x in thermo.press])+",\n"
 
   print(msg)
 
@@ -63,15 +65,15 @@ def main():
   time_end = 10.0
   timestep = 1.0
 
-  temp = 288.15
-  rho = 1.225
-  press = 101325
-  qvap = 0.015
-  qcond = 0.0
-  qice = 0.0
-  qrain = 0.0
-  qsnow = 0.0
-  qgrau = 0.0
+  temp = np.array([288.15])
+  rho = np.array([1.225])
+  press = np.array([101325])
+  qvap = np.array([0.015])
+  qcond = np.array([0.0])
+  qice = np.array([0.0])
+  qrain = np.array([0.0])
+  qsnow = np.array([0.0])
+  qgrau = np.array([0.0])
   thermo = Thermodynamics(temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau)
 
   nvec = 1

--- a/tests/test_case_0dparcel/run_0dparcel_test_case.py
+++ b/tests/test_case_0dparcel/run_0dparcel_test_case.py
@@ -8,7 +8,7 @@ Created Date: Wednesday 28th February 2024
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Friday 1st March 2024
+Last Modified: Monday 17th June 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -98,7 +98,7 @@ def plot_0dparcel_thermodynamics(out, binpath, run_name):
   plot_variable_on_axis(axs[0], time, out.press)
   plot_variable_on_axis(axs[1], time, out.rho)
   plot_variable_on_axis(axs[2], time, out.temp)
-  plot_thetas_on_axis(axs[3], time, out.temp, out.press)
+  plot_thetas_on_axis(axs[3], time, out.temp, out.press, out.press.values[0])
 
   for ax in axs:
     ax.set_xlabel(out.time.name+" /"+out.time.units)
@@ -165,7 +165,7 @@ def plot_variable_on_axis(ax, time, var):
   ax.plot(time, var.values)
   ax.set_ylabel(var.name+" /"+var.units)
 
-def plot_thetas_on_axis(ax, time, temp, press):
+def plot_thetas_on_axis(ax, time, temp, press, press0):
   """Plot potential temperature(s) on a specified axis.
 
   This function calculates and plots potential temperature(s) against time on a specified axis.
@@ -179,7 +179,7 @@ def plot_thetas_on_axis(ax, time, temp, press):
   Returns:
       None
   """
-  theta_dry = calcs.dry_potential_temperature(temp.values, press.values)
+  theta_dry = calcs.dry_potential_temperature(temp.values, press.values, press0)
   ax.plot(time, theta_dry, label="dry")
   ax.set_ylim(theta_dry[0]-1, theta_dry[0]+1)
   ax.legend()

--- a/tests/test_microphysics_scheme.py
+++ b/tests/test_microphysics_scheme.py
@@ -8,7 +8,7 @@ Created Date: Tuesday 27th February 2024
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Thursday 29th February 2024
+Last Modified: Monday 17th June 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -18,6 +18,7 @@ File Description:
 mock unit tests for Python microphysics module
 '''
 
+import numpy as np
 
 from libs.src_py.mock_microphysics_scheme import MicrophysicsScheme
 from libs.src_py.microphysics_scheme_wrapper import MicrophysicsSchemeWrapper
@@ -69,15 +70,15 @@ def test_microphys_with_wrapper():
 	microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 
 	timestep = 1.0
-	temp = 288.15
-	rho = 1.225
-	press = 101325
-	qvap = 0.015
-	qcond = 0.0001
-	qice = 0.0002
-	qrain = 0.0003
-	qsnow = 0.0004
-	qgrau = 0.0005
+	temp = np.array([288.15])
+	rho = np.array([1.225])
+	press = np.array([101325])
+	qvap = np.array([0.015])
+	qcond = np.array([0.0001])
+	qice = np.array([0.0002])
+	qrain = np.array([0.0003])
+	qsnow = np.array([0.0004])
+	qgrau = np.array([0.0005])
 
 	thermo = Thermodynamics(temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau)
 

--- a/tests/test_mock_cxx.py
+++ b/tests/test_mock_cxx.py
@@ -8,7 +8,7 @@ Created Date: Wednesday 28th February 2024
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Wednesday 28th February 2024
+Last Modified: Monday 17th June 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License


### PR DESCRIPTION
- Require that all the variables in the Thermodynamics class are arrays. 
- Modify scripts to handle change in datatypes from float to np.ndarray.