### PR TITLE
minor fixes for using np.array and deepcopy

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,6 +1,6 @@
 name: microtestsenv
 dependencies:
-    - python>=3.9
+    - python>=3.9,<3.13
     - pytest
     - sphinx
     - conda-forge::doxygen>=1.10.0

--- a/libs/pympdata_microphysics/bulk_scheme_condensation.py
+++ b/libs/pympdata_microphysics/bulk_scheme_condensation.py
@@ -23,6 +23,8 @@ import numpy as np
 from ..thermo.thermodynamics import Thermodynamics
 from PyMPDATA_examples import Shipway_and_Hill_2012 as kid
 
+from copy import deepcopy
+
 
 def bulk_scheme_condensation(temp, press, qvap, qcond):
     """
@@ -94,14 +96,15 @@ class MicrophysicsSchemeWrapper:
             Thermodynamics: Updated thermodynamic properties after microphysics computations.
         """
 
-        temp = thermo.temp
-        press = thermo.press
-        qvap = thermo.massmix_ratios[0]
-        qcond = thermo.massmix_ratios[1]
+        cp_thermo = deepcopy(thermo)
+        temp = cp_thermo.temp
+        press = cp_thermo.press
+        qvap = cp_thermo.massmix_ratios[0]
+        qcond = cp_thermo.massmix_ratios[1]
 
         qvap, qcond = bulk_scheme_condensation(temp, press, qvap, qcond)
 
-        thermo.massmix_ratios[0] = qvap
-        thermo.massmix_ratios[1] = qcond
+        cp_thermo.massmix_ratios[0] = qvap
+        cp_thermo.massmix_ratios[1] = qcond
 
-        return thermo
+        return cp_thermo

--- a/libs/src_mock_py/microphysics_scheme_wrapper.py
+++ b/libs/src_mock_py/microphysics_scheme_wrapper.py
@@ -8,7 +8,7 @@ Created Date: Wednesday 28th February 2024
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Sunday 1st September 2024
+Last Modified: Monday 11th November 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -21,6 +21,8 @@ and run scripts
 
 from ..thermo.thermodynamics import Thermodynamics
 from .mock_microphysics_scheme import MicrophysicsScheme
+
+from copy import deepcopy
 
 
 class MicrophysicsSchemeWrapper:
@@ -37,7 +39,7 @@ class MicrophysicsSchemeWrapper:
           Number of grid points in vertical direction.
         ivstart (int):
           Start index for horizontal direction.
-        dz (float):
+        dz (np.ndarray):
           Layer thickness of full levels (m).
         qnc (float):
           Cloud number concentration.
@@ -49,7 +51,7 @@ class MicrophysicsSchemeWrapper:
           Number of grid points in vertical direction.
         ivstart (int):
           Start index for horizontal direction.
-        dz (float):
+        dz (np.ndarray):
           Layer thickness of full levels (m).
         qnc (float):
           Cloud number concentration.
@@ -68,7 +70,7 @@ class MicrophysicsSchemeWrapper:
             Number of grid points in vertical direction.
           ivstart (int):
             Start index for horizontal direction.
-          dz (float):
+          dz (np.ndarray):
             Layer thickness of full levels (m).
           qnc (float):
             Cloud number concentration.
@@ -125,11 +127,12 @@ class MicrophysicsSchemeWrapper:
 
         """
 
+        cp_thermo = deepcopy(thermo)
         dt = timestep
-        t = thermo.temp
-        rho = thermo.rho
-        p = thermo.press
-        qv, qc, qi, qr, qs, qg = thermo.massmix_ratios
+        t = cp_thermo.temp
+        rho = cp_thermo.rho
+        p = cp_thermo.press
+        qv, qc, qi, qr, qs, qg = cp_thermo.massmix_ratios
 
         t, qv, qc, qi, qr, qs, qg, prr_gsp, pflx = self.microphys.run(
             self.nvec,
@@ -149,7 +152,7 @@ class MicrophysicsSchemeWrapper:
             self.qnc,
         )
 
-        thermo.temp = t
-        thermo.massmix_ratios = [qv, qc, qi, qr, qs, qg]
+        cp_thermo.temp = t
+        cp_thermo.massmix_ratios = [qv, qc, qi, qr, qs, qg]
 
-        return thermo
+        return cp_thermo

--- a/libs/src_mock_py/mock_microphysics_scheme.py
+++ b/libs/src_mock_py/mock_microphysics_scheme.py
@@ -8,7 +8,7 @@ Created Date: Tuesday 27th February 2024
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Sunday 1st September 2024
+Last Modified: Monday 11th November 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -59,9 +59,9 @@ class MicrophysicsScheme:
               Number of grid points in vertical direction.
             ivstart (int):
               Start index for horizontal direction.
-            dt (float):
+            dt (np.ndarray):
               Times-tep for integration of microphysics (s)
-            dz (float):
+            dz (np.ndarray):
               Layer thickness of full levels (m).
             t (np.ndarray):
               Temperature (K).

--- a/libs/thermo/output_thermodynamics.py
+++ b/libs/thermo/output_thermodynamics.py
@@ -31,7 +31,7 @@ class OutputVariable:
           Name of variable.
         units (string):
           Units of variable.
-        values (any):
+        values (np.ndarray):
           Values of variable; must be able to be appended to.
     """
 

--- a/libs/thermo/thermodynamics.py
+++ b/libs/thermo/thermodynamics.py
@@ -8,7 +8,7 @@ Created Date: Wednesday 28th February 2024
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Monday 2nd September 2024
+Last Modified: Monday 11th November 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -18,6 +18,7 @@ File Description:
 """
 
 import numpy as np
+from copy import deepcopy
 
 
 class Thermodynamics:
@@ -93,7 +94,7 @@ class Thermodynamics:
             qgrau (np.array): Specific graupel content (kg/kg)
 
         """
-        self.temp = temp
-        self.rho = rho
-        self.press = press
-        self.massmix_ratios = [qvap, qcond, qice, qrain, qsnow, qgrau]
+        self.temp = deepcopy(temp)
+        self.rho = deepcopy(rho)
+        self.press = deepcopy(press)
+        self.massmix_ratios = deepcopy([qvap, qcond, qice, qrain, qsnow, qgrau])

--- a/libs/thermo/thermodynamics.py
+++ b/libs/thermo/thermodynamics.py
@@ -29,42 +29,42 @@ class Thermodynamics:
     content (mass mixing ratio) of vapour and condensates.
 
     Parameters:
-      temp (np.array):
+      temp (np.ndarray):
         Temperature (K).
-      rho (np.array):
+      rho (np.ndarray):
         Density of moist air (kg/m3).
-      press (np.array):
+      press (np.ndarray):
         Pressure (Pa).
-      qvap (np.array):
+      qvap (np.ndarray):
         Specific water vapor content (kg/kg).
-      qcond (np.array):
+      qcond (np.ndarray):
         Specific cloud water content (kg/kg).
-      qice (np.array):
+      qice (np.ndarray):
         Specific cloud ice content (kg/kg).
-      qrain (np.array):
+      qrain (np.ndarray):
         Specific rain content (kg/kg).
-      qsnow (np.array):
+      qsnow (np.ndarray):
         Specific snow content kg/kg).
-      qgrau (np.array):
+      qgrau (np.ndarray):
         Specific graupel content (kg/kg).
 
     Attributes:
-      temp (np.array):
+      temp (np.ndarray):
         Temperature (K).
-      rho (np.array):
+      rho (np.ndarray):
         Density of moist air (kg/m3).
-      press (np.array):
+      press (np.ndarray):
         Pressure (Pa).
       massmix_ratios (tuple):
         Specific content of vapour and condensates (see below).
 
       massmax_ratios consists of the following:
-              massmix_ratios[0] = qvap (np.array): Specific water vapor content (kg/kg)\n
-              massmix_ratios[1] = qcond (np.array): Specific cloud water content (kg/kg)\n
-              massmix_ratios[2] = qice (np.array): Specific cloud ice content (kg/kg)\n
-              massmix_ratios[3] = qrain (np.array): Specific rain content (kg/kg)\n
-              massmix_ratios[4] = qsnow (np.array): Specific snow content kg/kg)\n
-              massmix_ratios[5] = qgrau (np.array): Specific graupel content (kg/kg).
+              massmix_ratios[0] = qvap (np.ndarray): Specific water vapor content (kg/kg)\n
+              massmix_ratios[1] = qcond (np.ndarray): Specific cloud water content (kg/kg)\n
+              massmix_ratios[2] = qice (np.ndarray): Specific cloud ice content (kg/kg)\n
+              massmix_ratios[3] = qrain (np.ndarray): Specific rain content (kg/kg)\n
+              massmix_ratios[4] = qsnow (np.ndarray): Specific snow content kg/kg)\n
+              massmix_ratios[5] = qgrau (np.ndarray): Specific graupel content (kg/kg).
 
     """
 
@@ -83,15 +83,15 @@ class Thermodynamics:
         """Initialize a thermodynamics object with the given variables
 
         Parameters:
-            press (np.array): Pressure (Pa).
-            temp (np.array): Temperature (K).
-            rho (np.array): Density of moist air (kg/m3)
-            qvap (np.array): Specific water vapor content (kg/kg)
-            qcond (np.array): Specific cloud water content (kg/kg)
-            qice (np.array): Specific cloud ice content (kg/kg)
-            qrain (np.array): Specific rain content (kg/kg)
-            qsnow (np.array): Specific snow content kg/kg)
-            qgrau (np.array): Specific graupel content (kg/kg)
+            press (np.ndarray): Pressure (Pa).
+            temp (np.ndarray): Temperature (K).
+            rho (np.ndarray): Density of moist air (kg/m3)
+            qvap (np.ndarray): Specific water vapor content (kg/kg)
+            qcond (np.ndarray): Specific cloud water content (kg/kg)
+            qice (np.ndarray): Specific cloud ice content (kg/kg)
+            qrain (np.ndarray): Specific rain content (kg/kg)
+            qsnow (np.ndarray): Specific snow content kg/kg)
+            qgrau (np.ndarray): Specific graupel content (kg/kg)
 
         """
         self.temp = deepcopy(temp)

--- a/scripts/using_microphysics_scheme_example.py
+++ b/scripts/using_microphysics_scheme_example.py
@@ -8,7 +8,7 @@ Created Date: Tuesday 27th February 2024
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Monday 2nd September 2024
+Last Modified: Monday 11th November 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -81,7 +81,7 @@ def main():
     nvec = 1
     ke = 1
     ivstart = 0
-    dz = 10
+    dz = np.array([10])
     qnc = 500
     microphys = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 

--- a/scripts/using_microphysics_scheme_example.py
+++ b/scripts/using_microphysics_scheme_example.py
@@ -67,21 +67,21 @@ def main():
     time_end = 10.0
     timestep = 1.0
 
-    temp = np.array([288.15])
-    rho = np.array([1.225])
-    press = np.array([101325])
-    qvap = np.array([0.015])
-    qcond = np.array([0.0])
-    qice = np.array([0.0])
-    qrain = np.array([0.0])
-    qsnow = np.array([0.0])
-    qgrau = np.array([0.0])
+    temp = np.array([288.15], dtype=np.float64)
+    rho = np.array([1.225], dtype=np.float64)
+    press = np.array([101325], dtype=np.float64)
+    qvap = np.array([0.015], dtype=np.float64)
+    qcond = np.array([0.0], dtype=np.float64)
+    qice = np.array([0.0], dtype=np.float64)
+    qrain = np.array([0.0], dtype=np.float64)
+    qsnow = np.array([0.0], dtype=np.float64)
+    qgrau = np.array([0.0], dtype=np.float64)
     thermo = Thermodynamics(temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau)
 
     nvec = 1
     ke = 1
     ivstart = 0
-    dz = np.array([10])
+    dz = np.array([10], dtype=np.float64)
     qnc = 500
     microphys = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 

--- a/tests/test_case_0dparcel/adiabatic_motion.py
+++ b/tests/test_case_0dparcel/adiabatic_motion.py
@@ -189,17 +189,29 @@ class AdiabaticMotion:
         Returns:
             Thermodynamics: Updated thermodynamic state of the air.
         """
+        assert (
+            thermo.temp.size == 1
+        ), "AdiabaticMotion only applicable to 0-D parcel (1 element)"
+        assert (
+            thermo.rho.size == 1
+        ), "AdiabaticMotion only applicable to 0-D parcel (1 element)"
+        assert (
+            thermo.press.size == 1
+        ), "AdiabaticMotion only applicable to 0-D parcel (1 element)"
+        assert (
+            thermo.massmix_ratios[0].size == 1
+        ), "AdiabaticMotion only applicable to 0-D parcel (1 element)"
 
         t0, t1 = time, time + timestep
-        qvap = thermo.massmix_ratios[0]
+        qvap = thermo.massmix_ratios[0][0]
 
-        y0 = [thermo.temp, thermo.rho, thermo.press]
+        y0 = [thermo.temp[0], thermo.rho[0], thermo.press[0]]
         temp, rho, press = integrate.odeint(
             self.adiabatic_odes, y0, [t0, t1], args=(qvap,)
         )[1]
 
-        thermo.temp = temp
-        thermo.rho = rho
-        thermo.press = press
+        thermo.temp = np.array([temp], dtype=np.float64)
+        thermo.rho = np.array([rho], dtype=np.float64)
+        thermo.press = np.array([press], dtype=np.float64)
 
         return thermo

--- a/tests/test_case_0dparcel/run_0dparcel.py
+++ b/tests/test_case_0dparcel/run_0dparcel.py
@@ -47,7 +47,7 @@ def run_0dparcel(time, time_end, timestep, thermo, microphys_scheme):
 
     ### data to output during model run
     ntime = int(time_end / timestep) + 1
-    out = OutputThermodynamics([ntime])
+    out = OutputThermodynamics([ntime, 1])
 
     ### type of dynamics parcel will undergo
     amp = 11325  # amplitude of pressure sinusoid [Pa]

--- a/tests/test_case_0dparcel/test_mock_py.py
+++ b/tests/test_case_0dparcel/test_mock_py.py
@@ -8,7 +8,7 @@ Created Date: Wednesday 28th February 2024
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Monday 2nd September 2024
+Last Modified: Monday 11th November 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -18,6 +18,7 @@ File Description:
 perform test case for 0-D parcel model with mock python microphysics scheme
 """
 
+import numpy as np
 from pathlib import Path
 
 from .perform_0dparcel_test_case import perform_0dparcel_test_case
@@ -52,7 +53,7 @@ def test_mock_py_0dparcel():
           nvec (int): Number of horizontal points for the microphysics scheme.
           ke (float): Number of grid points in vertical direction for the microphysics scheme.
           ivstart (int): Start index for horizontal direction for the microphysics scheme.
-          dz (float): Layer thickness of full levels (m) for the microphysics scheme.
+          dz (np.ndarray): Layer thickness of full levels (m) for the microphysics scheme.
           qnc (float): Cloud number concentration.
 
     """
@@ -87,7 +88,7 @@ def test_mock_py_0dparcel():
     nvec = 1
     ke = 1
     ivstart = 0
-    dz = 10
+    dz = np.array([10])
     qnc = 500
     microphys_scheme = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 

--- a/tests/test_case_0dparcel/test_mock_py.py
+++ b/tests/test_case_0dparcel/test_mock_py.py
@@ -71,15 +71,15 @@ def test_mock_py_0dparcel():
     timestep = 1.0  # [s]
 
     ### initial thermodynamic conditions
-    temp = 288.15
-    rho = 1.225
-    press = 101325
-    qvap = 0.01
-    qcond = 0.02
-    qice = 0.03
-    qrain = 0.04
-    qsnow = 0.05
-    qgrau = 0.06
+    temp = np.array([288.15], dtype=np.float64)
+    rho = np.array([1.225], dtype=np.float64)
+    press = np.array([101325], dtype=np.float64)
+    qvap = np.array([0.01], dtype=np.float64)
+    qcond = np.array([0.02], dtype=np.float64)
+    qice = np.array([0.03], dtype=np.float64)
+    qrain = np.array([0.04], dtype=np.float64)
+    qsnow = np.array([0.05], dtype=np.float64)
+    qgrau = np.array([0.06], dtype=np.float64)
     thermo_init = Thermodynamics(
         temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
     )
@@ -88,7 +88,7 @@ def test_mock_py_0dparcel():
     nvec = 1
     ke = 1
     ivstart = 0
-    dz = np.array([10])
+    dz = np.array([10], dtype=np.float64)
     qnc = 500
     microphys_scheme = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 

--- a/tests/test_case_0dparcel/test_mock_py.py
+++ b/tests/test_case_0dparcel/test_mock_py.py
@@ -59,7 +59,7 @@ def test_mock_py_0dparcel():
     """
 
     ### label for test case to name data/plots with
-    run_name = "python_microphys_0dparcel"
+    run_name = "python_mockmicrophys_0dparcel"
 
     ### path to directory to save data/plots in after model run
     binpath = Path(__file__).parent.resolve() / "bin"  # i.e. [current directory]/bin/

--- a/tests/test_case_0dparcel/test_pympdata_bulk.py
+++ b/tests/test_case_0dparcel/test_pympdata_bulk.py
@@ -54,7 +54,7 @@ def test_pympdata_bulk_scheme_0dparcel():
     """
 
     ### label for test case to name data/plots with
-    run_name = "python_microphys_0dparcel"
+    run_name = "pympdata_bulkmicrophys_0dparcel"
 
     ### path to directory to save data/plots in after model run
     binpath = Path(__file__).parent.resolve() / "bin"  # i.e. [current directory]/bin/

--- a/tests/test_case_0dparcel/test_pympdata_bulk.py
+++ b/tests/test_case_0dparcel/test_pympdata_bulk.py
@@ -18,6 +18,7 @@ File Description:
 perform test case for 0-D parcel model with pyMPDATA bulk microphysics scheme
 """
 
+import numpy as np
 from pathlib import Path
 
 from .perform_0dparcel_test_case import perform_0dparcel_test_case
@@ -66,15 +67,15 @@ def test_pympdata_bulk_scheme_0dparcel():
     timestep = 1.0  # [s]
 
     ### initial thermodynamic conditions
-    temp = 288.15
-    rho = 1.225
-    press = 101325
-    qvap = 0.01
-    qcond = 0.02
-    qice = 0.03
-    qrain = 0.04
-    qsnow = 0.05
-    qgrau = 0.06
+    temp = np.array([288.15], dtype=np.float64)
+    rho = np.array([1.225], dtype=np.float64)
+    press = np.array([101325], dtype=np.float64)
+    qvap = np.array([0.01], dtype=np.float64)
+    qcond = np.array([0.02], dtype=np.float64)
+    qice = np.array([0.03], dtype=np.float64)
+    qrain = np.array([0.04], dtype=np.float64)
+    qsnow = np.array([0.05], dtype=np.float64)
+    qgrau = np.array([0.06], dtype=np.float64)
     thermo_init = Thermodynamics(
         temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
     )

--- a/tests/test_mock_py_microphysics_scheme.py
+++ b/tests/test_mock_py_microphysics_scheme.py
@@ -8,7 +8,7 @@ Created Date: Tuesday 27th February 2024
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Sunday 1st September 2024
+Last Modified: Monday 11th November 2024
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -41,7 +41,7 @@ def test_initialize_wrapper():
     nvec = 1
     ke = 1
     ivstart = 0
-    dz = 10
+    dz = np.array([10])
     qnc = 500
     microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 
@@ -52,7 +52,7 @@ def test_finalize_wrapper():
     nvec = 1
     ke = 1
     ivstart = 0
-    dz = 10
+    dz = np.array([10])
     qnc = 500
     microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 
@@ -65,7 +65,7 @@ def test_microphys_with_wrapper():
     nvec = 1
     ke = 1
     ivstart = 0
-    dz = 10
+    dz = np.array([10])
     qnc = 500
     microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 

--- a/tests/test_mock_py_microphysics_scheme.py
+++ b/tests/test_mock_py_microphysics_scheme.py
@@ -41,7 +41,7 @@ def test_initialize_wrapper():
     nvec = 1
     ke = 1
     ivstart = 0
-    dz = np.array([10])
+    dz = np.array([10], dtype=np.float64)
     qnc = 500
     microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 
@@ -52,7 +52,7 @@ def test_finalize_wrapper():
     nvec = 1
     ke = 1
     ivstart = 0
-    dz = np.array([10])
+    dz = np.array([10], dtype=np.float64)
     qnc = 500
     microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 
@@ -65,20 +65,20 @@ def test_microphys_with_wrapper():
     nvec = 1
     ke = 1
     ivstart = 0
-    dz = np.array([10])
+    dz = np.array([10], dtype=np.float64)
     qnc = 500
     microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 
     timestep = 1.0
-    temp = np.array([288.15])
-    rho = np.array([1.225])
-    press = np.array([101325])
-    qvap = np.array([0.015])
-    qcond = np.array([0.0001])
-    qice = np.array([0.0002])
-    qrain = np.array([0.0003])
-    qsnow = np.array([0.0004])
-    qgrau = np.array([0.0005])
+    temp = np.array([288.15], dtype=np.float64)
+    rho = np.array([1.225], dtype=np.float64)
+    press = np.array([101325], dtype=np.float64)
+    qvap = np.array([0.015], dtype=np.float64)
+    qcond = np.array([0.0001], dtype=np.float64)
+    qice = np.array([0.0002], dtype=np.float64)
+    qrain = np.array([0.0003], dtype=np.float64)
+    qsnow = np.array([0.0004], dtype=np.float64)
+    qgrau = np.array([0.0005], dtype=np.float64)
 
     thermo = Thermodynamics(temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau)
 

--- a/tests/test_pympdata_bulk_microphysics_scheme.py
+++ b/tests/test_pympdata_bulk_microphysics_scheme.py
@@ -28,10 +28,10 @@ from libs.thermo.thermodynamics import Thermodynamics
 
 
 def test_bulk_scheme_condensation():
-    temp = np.array([290])
-    press = np.array([10100])
-    qvap = np.array([0.999])
-    qcond = np.array([0.0002])
+    temp = np.array([290], dtype=np.float64)
+    press = np.array([10100], dtype=np.float64)
+    qvap = np.array([0.999], dtype=np.float64)
+    qcond = np.array([0.0002], dtype=np.float64)
     qvap, qcond = bulk_scheme_condensation(temp, press, qvap, qcond)
 
     qvap_correct = 0.30739488331808
@@ -58,15 +58,15 @@ def test_microphys_with_wrapper():
     microphys_wrapped = MicrophysicsSchemeWrapper()
 
     timestep = 1.0
-    temp = np.array([288.15])
-    rho = np.array([1.225])
-    press = np.array([101325])
-    qvap = np.array([0.015])
-    qcond = np.array([0.0001])
-    qice = np.array([0.0002])
-    qrain = np.array([0.0003])
-    qsnow = np.array([0.0004])
-    qgrau = np.array([0.0005])
+    temp = np.array([288.15], dtype=np.float64)
+    rho = np.array([1.225], dtype=np.float64)
+    press = np.array([101325], dtype=np.float64)
+    qvap = np.array([0.015], dtype=np.float64)
+    qcond = np.array([0.0001], dtype=np.float64)
+    qice = np.array([0.0002], dtype=np.float64)
+    qrain = np.array([0.0003], dtype=np.float64)
+    qsnow = np.array([0.0004], dtype=np.float64)
+    qgrau = np.array([0.0005], dtype=np.float64)
 
     thermo = Thermodynamics(temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau)
 


### PR DESCRIPTION
A series of minor changes:
- make 0-D parcel test case always use arrays for thermodynamics instead of scalars
- use deepcopy in microphysics wrappers
- change dz type from float to np.ndarray
- rename labels of mock and pympdata 0-D test cases