### PR TITLE
Add saturation adjustment scheme

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         args: [--linelength=100, "--filter=-runtime/references,-readability/braces,-build/include,-build/c++11"]
         types_or: [c, c++, cuda]
 -   repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v3.4.0
+    rev: v3.6.0
     hooks:
     -   id: conventional-pre-commit
         stages: [commit-msg]

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,6 +1,6 @@
 name: microtestsenv
 dependencies:
-    - python>=3.9,<3.13
+    - python=3.10 # stricly 3.10 for ICON Graupel bindings on Levante
     - pytest
     - sphinx
     - conda-forge::doxygen>=1.10.0

--- a/libs/icon_satadj/microphysics_scheme_wrapper.py
+++ b/libs/icon_satadj/microphysics_scheme_wrapper.py
@@ -21,7 +21,6 @@ and run scripts
 
 import os
 import sys
-import numpy as np
 from copy import deepcopy
 
 from ..thermo.thermodynamics import Thermodynamics
@@ -29,6 +28,7 @@ from ..thermo.thermodynamics import Thermodynamics
 sys.path.append(os.environ["PY_GRAUPEL_DIR"])
 # currently on Levante: export PY_GRAUPEL_DIR=/work/k20200/k202174/installed-muphys/lib64/
 import py_graupel
+
 
 class MicrophysicsSchemeWrapper:
     """A class wrapping around ICON's saturation adjustment as a MicrophysicsScheme
@@ -88,8 +88,10 @@ class MicrophysicsSchemeWrapper:
         self.ivstart = ivstart
         self.dz = dz
         self.qnc = qnc
-        self.microphys = py_graupel.Graupel() 
-        self.name = "Wrapper around " + "ICON Saturation Adjustment" # self.microphys.name
+        self.microphys = py_graupel.Graupel()
+        self.name = (
+            "Wrapper around " + "ICON Saturation Adjustment"
+        )  # self.microphys.name
 
     def initialize(self) -> int:
         """Initialise the microphysics scheme.
@@ -135,10 +137,8 @@ class MicrophysicsSchemeWrapper:
         """
 
         cp_thermo = deepcopy(thermo)
-        dt = timestep
         t = cp_thermo.temp
         rho = cp_thermo.rho
-        p = cp_thermo.press
         qv, qc, qi, qr, qs, qg = cp_thermo.massmix_ratios
 
         # temporary variable
@@ -146,16 +146,16 @@ class MicrophysicsSchemeWrapper:
 
         # call saturation adjustment
         py_graupel.saturation_adjustment(
-          ncells=self.nvec,
-          nlev=self.ke,
-          ta=t,
-          qv=qv,
-          qc=qc,
-          qr=qr,
-          total_ice=total_ice,
-          rho=rho,
+            ncells=self.nvec,
+            nlev=self.ke,
+            ta=t,
+            qv=qv,
+            qc=qc,
+            qr=qr,
+            total_ice=total_ice,
+            rho=rho,
         )
-  
+
         cp_thermo.temp = t
         cp_thermo.massmix_ratios = [qv, qc, qi, qr, qs, qg]
 

--- a/libs/icon_satadj/microphysics_scheme_wrapper.py
+++ b/libs/icon_satadj/microphysics_scheme_wrapper.py
@@ -1,0 +1,162 @@
+"""
+Copyright (c) 2024 MPI-M, Clara Bayley
+
+----- Microphysics Test Cases -----
+File: microphysics_scheme_wrapper.py
+Project: src_mock_py
+Created Date: Wednesday 28th February 2024
+Author: Clara Bayley (CB)
+Additional Contributors: Joerg Behrens, Georgiana Mania
+-----
+Last Modified: Sunday 1st September 2024
+Modified By: CB
+-----
+License: BSD 3-Clause "New" or "Revised" License
+https://opensource.org/licenses/BSD-3-Clause
+-----
+File Description:
+wrapper function for an instance of MicrophysicsScheme so it can be used by generic test cases
+and run scripts
+"""
+
+import os
+import sys
+import numpy as np
+from copy import deepcopy
+
+from ..thermo.thermodynamics import Thermodynamics
+
+sys.path.append(os.environ["PY_GRAUPEL_DIR"])
+# currently on Levante: export PY_GRAUPEL_DIR=/work/k20200/k202174/installed-muphys/lib64/
+import py_graupel
+
+class MicrophysicsSchemeWrapper:
+    """A class wrapping around ICON's saturation adjustment as a MicrophysicsScheme
+    (without graupel microphysics)
+
+    This class wraps around python bindings to the ICON one-moment saturation adjustment
+    to provide compatibility with the Python run scripts and tests in this project. It
+    initializes the ICON MicrophysicsScheme object and provides
+    wrappers around methods to initialize, finalize, and run the microphysics.
+
+    Args:
+        nvec (int):
+          Number of horizontal points.
+        ke (int):
+          Number of grid points in vertical direction.
+        ivstart (int):
+          Start index for horizontal direction.
+        dz (np.ndarray):
+          Layer thickness of full levels (m).
+        qnc (float):
+          Cloud number concentration.
+
+    Attributes:
+        nvec (int):
+          Number of horizontal points.
+        ke (int):
+          Number of grid points in vertical direction.
+        ivstart (int):
+          Start index for horizontal direction.
+        dz (np.ndarray):
+          Layer thickness of full levels (m).
+        qnc (float):
+          Cloud number concentration.
+        microphys (MicrophysicsScheme):
+          instance of Python MicrophysicsScheme.
+
+    """
+
+    def __init__(self, nvec, ke, ivstart, dz, qnc):
+        """Initialize the MicrophysicsSchemeWrapper object.
+
+        Args:
+          nvec (int):
+            Number of horizontal points.
+          ke (int):
+            Number of grid points in vertical direction.
+          ivstart (int):
+            Start index for horizontal direction.
+          dz (np.ndarray):
+            Layer thickness of full levels (m).
+          qnc (float):
+            Cloud number concentration.
+
+        """
+        self.nvec = nvec
+        self.ke = ke
+        self.ivstart = ivstart
+        self.dz = dz
+        self.qnc = qnc
+        self.microphys = py_graupel.Graupel() 
+        self.name = "Wrapper around " + "ICON Saturation Adjustment" # self.microphys.name
+
+    def initialize(self) -> int:
+        """Initialise the microphysics scheme.
+
+        This method calls the microphysics initialisation
+
+        Returns:
+            int: 0 upon successful initialisation
+        """
+
+        self.microphys.initialize()
+
+        return 0
+
+    def finalize(self) -> int:
+        """Finalise the microphysics scheme.
+
+        This method calls the microphysics finalisation.
+
+        Returns:
+            int: 0 upon successful finalisation.
+        """
+
+        self.microphys.finalize()
+
+        return 0
+
+    def run(self, timestep: float, thermo: Thermodynamics) -> Thermodynamics:
+        """Run the microphysics computations.
+
+        This method is a wrapper of the MicrophysicsScheme object's run function to call the
+        microphysics computations in a way that's compatible with the test and scripts in this project.
+
+        Args:
+            timestep (float):
+              Time-step for integration of microphysics (s)
+            thermo (Thermodynamics):
+              Thermodynamic properties.
+
+        Returns:
+            Thermodynamics: Updated thermodynamic properties after microphysics computations.
+
+        """
+
+        cp_thermo = deepcopy(thermo)
+        dt = timestep
+        t = cp_thermo.temp
+        rho = cp_thermo.rho
+        p = cp_thermo.press
+        qv, qc, qi, qr, qs, qg = cp_thermo.massmix_ratios
+
+        # temporary variable
+        total_ice = qg + qs + qi
+
+        # call saturation adjustment
+        py_graupel.saturation_adjustment(
+          ncells=self.nvec,
+          nlev=self.ke,
+          ta=t,
+          qv=qv,
+          qc=qc,
+          qr=qr,
+          total_ice=total_ice,
+          rho=rho,
+        )
+  
+        cp_thermo.temp = t
+        cp_thermo.massmix_ratios = [qv, qc, qi, qr, qs, qg]
+
+        return cp_thermo

--- a/libs/thermo/formulae.py
+++ b/libs/thermo/formulae.py
@@ -65,7 +65,7 @@ def moist_equiv_potential_temperature(
         press (array-like):
             Pressure values (Pa).
         qvap (array-like):
-            Mixing ratio of water vapour (Kg/Kg)
+            Mixing ratio of water vapour (kg/kg)
     Returns:
         array-like: The moist potential temperature (K).
     """
@@ -99,7 +99,7 @@ def moist_static_energy(
         press (array-like):
             Pressure values (Pa).
         qvap (array-like):
-            Mixing ratio of water vapour (Kg/Kg)
+            Mixing ratio of water vapour (kg/kg)
     Returns:
         array-like: The moist potential temperature (K).
     """

--- a/libs/thermo/output_thermodynamics.py
+++ b/libs/thermo/output_thermodynamics.py
@@ -121,14 +121,14 @@ class OutputThermodynamics:
 
         self.time = OutputVariable("time", "s", [shape[0]])
         self.temp = OutputVariable("temp", "K", shape)
-        self.rho = OutputVariable("rho", "Kg m-3", shape)
+        self.rho = OutputVariable("rho", "kg m-3", shape)
         self.press = OutputVariable("press", "Pa", shape)
-        self.qvap = OutputVariable("qvap", "Kg/Kg", shape)
-        self.qcond = OutputVariable("qcond", "Kg/Kg", shape)
-        self.qice = OutputVariable("qice", "Kg/Kg", shape)
-        self.qrain = OutputVariable("qrain", "Kg/Kg", shape)
-        self.qsnow = OutputVariable("qsnow", "Kg/Kg", shape)
-        self.qgrau = OutputVariable("qgrau", "Kg/Kg", shape)
+        self.qvap = OutputVariable("qvap", "kg/kg", shape)
+        self.qcond = OutputVariable("qcond", "kg/kg", shape)
+        self.qice = OutputVariable("qice", "kg/kg", shape)
+        self.qrain = OutputVariable("qrain", "kg/kg", shape)
+        self.qsnow = OutputVariable("qsnow", "kg/kg", shape)
+        self.qgrau = OutputVariable("qgrau", "kg/kg", shape)
 
         if zhalf is not None:
             self.zhalf = OutputVariable("zhalf", "m", [len(zhalf)])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pre-commit
 pytest
 sphinx
 furo

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ matplotlib
 xarray
 PyMPDATA
 PyMPDATA-examples
+metpy

--- a/scripts/using_microphysics_scheme_example.py
+++ b/scripts/using_microphysics_scheme_example.py
@@ -34,7 +34,7 @@ def print_message(time, thermo):
 
     msg = "time = {:.1f}s:\n".format(time)
     msg += "   T = " + str(["{:.2f}K".format(x) for x in thermo.temp]) + ",\n"
-    msg += " rho = " + str(["{:.3f}Kgm^-3".format(x) for x in thermo.rho]) + ",\n"
+    msg += " rho = " + str(["{:.3f}kgm^-3".format(x) for x in thermo.rho]) + ",\n"
     msg += "   P = " + str(["{:.0f}Pa".format(x) for x in thermo.press]) + ",\n"
 
     print(msg)

--- a/tests/test_case_0dparcel/adiabatic_motion.py
+++ b/tests/test_case_0dparcel/adiabatic_motion.py
@@ -39,9 +39,9 @@ class AdiabaticMotion:
         omega (float):
           Angular frequency of pressure sinusoid (tau is time period) [radians s^-1].
         cp_dry (float):
-          Specific heat capacity of water vapour [J/Kg/K] (IAPWS97 at 273.15K).
+          Specific heat capacity of water vapour [J/kg/K] (IAPWS97 at 273.15K).
         rgas_dry (float):
-          Specific gas constant for dry air [J/Kg/K] (approx. 287 J/Kg/K).
+          Specific gas constant for dry air [J/kg/K] (approx. 287 J/kg/K).
         epsilon (float):
           Ratio of gas constants, dry air / water vapour (approx. 0.622).
     """
@@ -56,14 +56,14 @@ class AdiabaticMotion:
               Time period of the pressure sinusoid [s].
         """
 
-        rgas_univ = 8.314462618  # universal molar gas constant [J/Kg/K]
-        mr_dry = 0.028966216  # molecular mass of dry air [Kg/mol]
-        mr_water = 0.01801528  # molecular mass of water [Kg/mol]
+        rgas_univ = 8.314462618  # universal molar gas constant [J/kg/K]
+        mr_dry = 0.028966216  # molecular mass of dry air [kg/mol]
+        mr_water = 0.01801528  # molecular mass of water [kg/mol]
 
-        self.cp_dry = 1004.64  # specific heat capacity of water vapour [J/Kg/K] (IAPWS97 at 273.15K)
+        self.cp_dry = 1004.64  # specific heat capacity of water vapour [J/kg/K] (IAPWS97 at 273.15K)
         self.rgas_dry = (
             rgas_univ / mr_dry
-        )  # specific gas constant for dry air [J/Kg/K] (approx. 287 J/Kg/K)
+        )  # specific gas constant for dry air [J/kg/K] (approx. 287 J/kg/K)
         self.epsilon = (
             mr_water / mr_dry
         )  # ratio of gas constants, dry air / water vapour (approx. 0.622)
@@ -110,7 +110,7 @@ class AdiabaticMotion:
 
         Args:
             rho (np.ndarray):
-              Density of air [Kg/m^3].
+              Density of air [kg/m^3].
             dpress_dt (np.ndarray):
               Rate of change of pressure with respect to time [Pa/s].
 
@@ -142,16 +142,16 @@ class AdiabaticMotion:
             temp (np.ndarray):
               Temperature of air [K].
             rho (np.ndarray):
-              Density of air [Kg/m^3].
+              Density of air [kg/m^3].
             qvap (np.ndarray):
-              Mass mixing ratio of water vapor [Kg/Kg].
+              Mass mixing ratio of water vapor [kg/kg].
             dpress_dt (np.ndarray):
               Rate of change of pressure with respect to time [Pa/s].
             dtemp_dt (np.ndarray):
               Rate of change of temperature with respect to time [K/s].
 
         Returns:
-            np.ndarray: Rate of change of density with respect to time [Kg/m^3/s].
+            np.ndarray: Rate of change of density with respect to time [kg/m^3/s].
         """
 
         rgas_eff = self.rgas_dry * (1 + qvap / self.epsilon)

--- a/tests/test_case_0dparcel/test_icon_satadj.py
+++ b/tests/test_case_0dparcel/test_icon_satadj.py
@@ -1,0 +1,97 @@
+"""
+Copyright (c) 2024 MPI-M, Clara Bayley
+
+----- Microphysics Test Cases -----
+File: test_mock_py.py
+Project: test_case_0dparcel
+Created Date: Wednesday 28th February 2024
+Author: Clara Bayley (CB)
+Additional Contributors:
+-----
+Last Modified: Monday 11th November 2024
+Modified By: CB
+-----
+License: BSD 3-Clause "New" or "Revised" License
+https://opensource.org/licenses/BSD-3-Clause
+-----
+File Description:
+perform test case for 0-D parcel model with mock python microphysics scheme
+"""
+import numpy as np
+from pathlib import Path
+import numpy as np
+
+from libs.icon_satadj.microphysics_scheme_wrapper import MicrophysicsSchemeWrapper
+from .perform_0dparcel_test_case import perform_0dparcel_test_case
+from libs.thermo.thermodynamics import Thermodynamics
+
+def test_icon_satadj_0dparcel():
+    """runs 0-D parcel model test using ICON's saturation adjustment as a MicrophysicsScheme
+    (without graupel microphysics).
+
+    This function sets up initial conditions and parameters for running a 0-D parcel model
+    test case using a wrapper around python bindings to ICON's saturation adjustment.
+    It then runs the 0-D parcel test case as specified.
+
+    Test Parameters:
+        Timestepping:
+          time_init (float): Initial time for the simulation (s).
+          time_end (float): End time for the simulation (s).
+          timestep (float): Timestep for the simulation (s).
+        Initial thermodynamics:
+          temp (np.ndarray): Initial temperature (K).
+          rho (np.ndarray): Initial density of moist air (kg/m3).
+          press (np.ndarray): Initial pressure (Pa).
+          qvap (np.ndarray): Initial specific water vapor content (kg/kg).
+          qcond (np.ndarray): Initial specific cloud water content (kg/kg).
+          qice (np.ndarray): Initial specific cloud ice content (kg/kg).
+          qrain (np.ndarray): Initial specific rain content (kg/kg).
+          qsnow (np.ndarray): Initial specific snow content (kg/kg).
+          qgrau (np.ndarray): Initial specific graupel content (kg/kg).
+        Microphysics Scheme:
+          nvec (int): Number of horizontal points for the microphysics scheme.
+          ke (float): Number of grid points in vertical direction for the microphysics scheme.
+          ivstart (int): Start index for horizontal direction for the microphysics scheme.
+          dz (np.ndarray): Layer thickness of full levels (m) for the microphysics scheme.
+          qnc (float): Cloud number concentration.
+
+    """
+
+    ### label for test case to name data/plots with
+    run_name = "icon_satadj_0dparcel"
+
+    ### path to directory to save data/plots in after model run
+    binpath = Path(__file__).parent.resolve() / "bin"  # i.e. [current directory]/bin/
+    binpath.mkdir(parents=False, exist_ok=True)
+
+    ### time parameters
+    time_init = 0.0  # [s]
+    time_end = 240.0  # [s]
+    timestep = 1.0  # [s]
+
+    ### initial thermodynamic conditions
+    temp = np.array([288.15], dtype=np.float64)
+    rho = np.array([1.225], dtype=np.float64)
+    press = np.array([101325], dtype=np.float64)
+    qvap = np.array([0.01], dtype=np.float64)
+    qcond = np.array([0.02], dtype=np.float64)
+    qice = np.array([0.0], dtype=np.float64)
+    qrain = np.array([0.04], dtype=np.float64)
+    qsnow = np.array([0.0], dtype=np.float64)
+    qgrau = np.array([0.0], dtype=np.float64)
+    thermo_init = Thermodynamics(
+        temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
+    )
+
+    ### microphysics scheme to use (within a wrapper)
+    nvec = 1
+    ke = 1
+    ivstart = 0
+    dz = np.array([100], dtype=np.float64)
+    qnc = 500
+    microphys_scheme = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
+
+    ### Perform 0-D parcel model test case using chosen setup
+    perform_0dparcel_test_case(
+        time_init, time_end, timestep, thermo_init, microphys_scheme, binpath, run_name
+    )

--- a/tests/test_case_0dparcel/test_icon_satadj.py
+++ b/tests/test_case_0dparcel/test_icon_satadj.py
@@ -18,81 +18,92 @@ File Description:
 perform test case for 0-D parcel model with mock python microphysics scheme
 """
 
-import numpy as np
-from pathlib import Path
+import os
 
-from libs.icon_satadj.microphysics_scheme_wrapper import MicrophysicsSchemeWrapper
-from .perform_0dparcel_test_case import perform_0dparcel_test_case
-from libs.thermo.thermodynamics import Thermodynamics
+path = os.environ.get("PY_GRAUPEL_DIR")
+if path and path is not None:
+    import numpy as np
+    from pathlib import Path
 
+    from libs.icon_satadj.microphysics_scheme_wrapper import MicrophysicsSchemeWrapper
+    from .perform_0dparcel_test_case import perform_0dparcel_test_case
+    from libs.thermo.thermodynamics import Thermodynamics
 
-def test_icon_satadj_0dparcel():
-    """runs 0-D parcel model test using ICON's saturation adjustment as a MicrophysicsScheme
-    (without graupel microphysics).
+    def test_icon_satadj_0dparcel():
+        """runs 0-D parcel model test using ICON's saturation adjustment as a MicrophysicsScheme
+        (without graupel microphysics).
 
-    This function sets up initial conditions and parameters for running a 0-D parcel model
-    test case using a wrapper around python bindings to ICON's saturation adjustment.
-    It then runs the 0-D parcel test case as specified.
+        This function sets up initial conditions and parameters for running a 0-D parcel model
+        test case using a wrapper around python bindings to ICON's saturation adjustment.
+        It then runs the 0-D parcel test case as specified.
 
-    Test Parameters:
-        Timestepping:
-          time_init (float): Initial time for the simulation (s).
-          time_end (float): End time for the simulation (s).
-          timestep (float): Timestep for the simulation (s).
-        Initial thermodynamics:
-          temp (np.ndarray): Initial temperature (K).
-          rho (np.ndarray): Initial density of moist air (kg/m3).
-          press (np.ndarray): Initial pressure (Pa).
-          qvap (np.ndarray): Initial specific water vapor content (kg/kg).
-          qcond (np.ndarray): Initial specific cloud water content (kg/kg).
-          qice (np.ndarray): Initial specific cloud ice content (kg/kg).
-          qrain (np.ndarray): Initial specific rain content (kg/kg).
-          qsnow (np.ndarray): Initial specific snow content (kg/kg).
-          qgrau (np.ndarray): Initial specific graupel content (kg/kg).
-        Microphysics Scheme:
-          nvec (int): Number of horizontal points for the microphysics scheme.
-          ke (float): Number of grid points in vertical direction for the microphysics scheme.
-          ivstart (int): Start index for horizontal direction for the microphysics scheme.
-          dz (np.ndarray): Layer thickness of full levels (m) for the microphysics scheme.
-          qnc (float): Cloud number concentration.
+        Test Parameters:
+            Timestepping:
+              time_init (float): Initial time for the simulation (s).
+              time_end (float): End time for the simulation (s).
+              timestep (float): Timestep for the simulation (s).
+            Initial thermodynamics:
+              temp (np.ndarray): Initial temperature (K).
+              rho (np.ndarray): Initial density of moist air (kg/m3).
+              press (np.ndarray): Initial pressure (Pa).
+              qvap (np.ndarray): Initial specific water vapor content (kg/kg).
+              qcond (np.ndarray): Initial specific cloud water content (kg/kg).
+              qice (np.ndarray): Initial specific cloud ice content (kg/kg).
+              qrain (np.ndarray): Initial specific rain content (kg/kg).
+              qsnow (np.ndarray): Initial specific snow content (kg/kg).
+              qgrau (np.ndarray): Initial specific graupel content (kg/kg).
+            Microphysics Scheme:
+              nvec (int): Number of horizontal points for the microphysics scheme.
+              ke (float): Number of grid points in vertical direction for the microphysics scheme.
+              ivstart (int): Start index for horizontal direction for the microphysics scheme.
+              dz (np.ndarray): Layer thickness of full levels (m) for the microphysics scheme.
+              qnc (float): Cloud number concentration.
 
-    """
+        """
 
-    ### label for test case to name data/plots with
-    run_name = "icon_satadj_0dparcel"
+        ### label for test case to name data/plots with
+        run_name = "icon_satadj_0dparcel"
 
-    ### path to directory to save data/plots in after model run
-    binpath = Path(__file__).parent.resolve() / "bin"  # i.e. [current directory]/bin/
-    binpath.mkdir(parents=False, exist_ok=True)
+        ### path to directory to save data/plots in after model run
+        binpath = (
+            Path(__file__).parent.resolve() / "bin"
+        )  # i.e. [current directory]/bin/
+        binpath.mkdir(parents=False, exist_ok=True)
 
-    ### time parameters
-    time_init = 0.0  # [s]
-    time_end = 240.0  # [s]
-    timestep = 1.0  # [s]
+        ### time parameters
+        time_init = 0.0  # [s]
+        time_end = 240.0  # [s]
+        timestep = 1.0  # [s]
 
-    ### initial thermodynamic conditions
-    temp = np.array([288.15], dtype=np.float64)
-    rho = np.array([1.225], dtype=np.float64)
-    press = np.array([101325], dtype=np.float64)
-    qvap = np.array([0.01], dtype=np.float64)
-    qcond = np.array([0.02], dtype=np.float64)
-    qice = np.array([0.0], dtype=np.float64)
-    qrain = np.array([0.04], dtype=np.float64)
-    qsnow = np.array([0.0], dtype=np.float64)
-    qgrau = np.array([0.0], dtype=np.float64)
-    thermo_init = Thermodynamics(
-        temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
-    )
+        ### initial thermodynamic conditions
+        temp = np.array([288.15], dtype=np.float64)
+        rho = np.array([1.225], dtype=np.float64)
+        press = np.array([101325], dtype=np.float64)
+        qvap = np.array([0.01], dtype=np.float64)
+        qcond = np.array([0.02], dtype=np.float64)
+        qice = np.array([0.0], dtype=np.float64)
+        qrain = np.array([0.04], dtype=np.float64)
+        qsnow = np.array([0.0], dtype=np.float64)
+        qgrau = np.array([0.0], dtype=np.float64)
+        thermo_init = Thermodynamics(
+            temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
+        )
 
-    ### microphysics scheme to use (within a wrapper)
-    nvec = 1
-    ke = 1
-    ivstart = 0
-    dz = np.array([100], dtype=np.float64)
-    qnc = 500
-    microphys_scheme = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
+        ### microphysics scheme to use (within a wrapper)
+        nvec = 1
+        ke = 1
+        ivstart = 0
+        dz = np.array([100], dtype=np.float64)
+        qnc = 500
+        microphys_scheme = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 
-    ### Perform 0-D parcel model test case using chosen setup
-    perform_0dparcel_test_case(
-        time_init, time_end, timestep, thermo_init, microphys_scheme, binpath, run_name
-    )
+        ### Perform 0-D parcel model test case using chosen setup
+        perform_0dparcel_test_case(
+            time_init,
+            time_end,
+            timestep,
+            thermo_init,
+            microphys_scheme,
+            binpath,
+            run_name,
+        )

--- a/tests/test_case_0dparcel/test_icon_satadj.py
+++ b/tests/test_case_0dparcel/test_icon_satadj.py
@@ -17,13 +17,14 @@ https://opensource.org/licenses/BSD-3-Clause
 File Description:
 perform test case for 0-D parcel model with mock python microphysics scheme
 """
+
 import numpy as np
 from pathlib import Path
-import numpy as np
 
 from libs.icon_satadj.microphysics_scheme_wrapper import MicrophysicsSchemeWrapper
 from .perform_0dparcel_test_case import perform_0dparcel_test_case
 from libs.thermo.thermodynamics import Thermodynamics
+
 
 def test_icon_satadj_0dparcel():
     """runs 0-D parcel model test using ICON's saturation adjustment as a MicrophysicsScheme

--- a/tests/test_case_1dkid/test_icon_satadj.py
+++ b/tests/test_case_1dkid/test_icon_satadj.py
@@ -1,0 +1,77 @@
+"""
+Copyright (c) 2024 MPI-M, Clara Bayley
+
+----- Microphysics Test Cases -----
+File: test_bulkkid.py
+Project: test_case_1dkid
+Created Date: Monday 2nd September 2024
+Author: Clara Bayley (CB)
+Additional Contributors:
+-----
+Last Modified: Wednesday 4th September 2024
+Modified By: Joerg Behrens, Georgiana Mania
+-----
+License: BSD 3-Clause "New" or "Revised" License
+https://opensource.org/licenses/BSD-3-Clause
+-----
+File Description:
+"""
+
+import numpy as np
+from pathlib import Path
+from PyMPDATA_examples.Shipway_and_Hill_2012 import si
+
+from .perform_1dkid_test_case import perform_1dkid_test_case
+from libs.thermo.thermodynamics import Thermodynamics
+from libs.icon_satadj.microphysics_scheme_wrapper import MicrophysicsSchemeWrapper
+
+
+def test_icon_satadj_scheme_1dkid():
+    """runs test of 1-D KiD rainshaft model using python bindings for
+    ICON's saturation adjustment as the microphysics scheme.
+
+    This function sets up initial conditions and parameters for running a 1-D KiD rainshaft
+    test case using the saturation adjustment from ICON's one-moment bulk microphysics scheme.
+    It then runs the test case as specified.
+    """
+    ### label for test case to name data/plots with
+    run_name = "icon_satadj_1dkid"
+
+    ### path to directory to save data/plots in after model run
+    binpath = Path(__file__).parent.resolve() / "bin"  # i.e. [current directory]/bin/
+    binpath.mkdir(parents=False, exist_ok=True)
+
+    ### time and grid parameters
+    z_delta = 25 * si.m
+    z_max = 3200 * si.m
+    timestep = 0.25 / 2 * si.s
+    time_end = 15 * si.minutes
+
+    ### initial thermodynamic conditions
+    assert z_max % z_delta == 0, "z limit is not a multiple of the grid spacing."
+    zeros = np.zeros(int(z_max / z_delta))
+    thermo_init = Thermodynamics(
+        zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros
+    )
+
+    ### microphysics scheme to use (within a wrapper)
+    nvec = 1
+    ke = 128
+    ivstart = 0
+    dz = np.array([25], dtype=np.float64)
+    qnc = 500
+
+    ### Call graupel
+    microphys_scheme = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
+
+    ### Perform test of 1-D KiD rainshaft model using chosen setup
+    perform_1dkid_test_case(
+        z_delta,
+        z_max,
+        time_end,
+        timestep,
+        thermo_init,
+        microphys_scheme,
+        binpath,
+        run_name,
+    )

--- a/tests/test_case_1dkid/test_icon_satadj.py
+++ b/tests/test_case_1dkid/test_icon_satadj.py
@@ -18,60 +18,66 @@ File Description:
 """
 
 import numpy as np
-from pathlib import Path
-from PyMPDATA_examples.Shipway_and_Hill_2012 import si
+import os
 
-from .perform_1dkid_test_case import perform_1dkid_test_case
-from libs.thermo.thermodynamics import Thermodynamics
-from libs.icon_satadj.microphysics_scheme_wrapper import MicrophysicsSchemeWrapper
+path = os.environ.get("PY_GRAUPEL_DIR")
+if path and path is not None:
+    from pathlib import Path
+    from PyMPDATA_examples.Shipway_and_Hill_2012 import si
 
+    from .perform_1dkid_test_case import perform_1dkid_test_case
+    from libs.thermo.thermodynamics import Thermodynamics
+    from libs.icon_satadj.microphysics_scheme_wrapper import MicrophysicsSchemeWrapper
 
-def test_icon_satadj_scheme_1dkid():
-    """runs test of 1-D KiD rainshaft model using python bindings for
-    ICON's saturation adjustment as the microphysics scheme.
+    def test_icon_satadj_scheme_1dkid():
+        """runs test of 1-D KiD rainshaft model using python bindings for
+        ICON's saturation adjustment as the microphysics scheme.
 
-    This function sets up initial conditions and parameters for running a 1-D KiD rainshaft
-    test case using the saturation adjustment from ICON's one-moment bulk microphysics scheme.
-    It then runs the test case as specified.
-    """
-    ### label for test case to name data/plots with
-    run_name = "icon_satadj_1dkid"
+        This function sets up initial conditions and parameters for running a 1-D KiD rainshaft
+        test case using the saturation adjustment from ICON's one-moment bulk microphysics scheme.
+        It then runs the test case as specified.
+        """
 
-    ### path to directory to save data/plots in after model run
-    binpath = Path(__file__).parent.resolve() / "bin"  # i.e. [current directory]/bin/
-    binpath.mkdir(parents=False, exist_ok=True)
+        ### label for test case to name data/plots with
+        run_name = "icon_satadj_1dkid"
 
-    ### time and grid parameters
-    z_delta = 25 * si.m
-    z_max = 3200 * si.m
-    timestep = 0.25 / 2 * si.s
-    time_end = 15 * si.minutes
+        ### path to directory to save data/plots in after model run
+        binpath = (
+            Path(__file__).parent.resolve() / "bin"
+        )  # i.e. [current directory]/bin/
+        binpath.mkdir(parents=False, exist_ok=True)
 
-    ### initial thermodynamic conditions
-    assert z_max % z_delta == 0, "z limit is not a multiple of the grid spacing."
-    zeros = np.zeros(int(z_max / z_delta))
-    thermo_init = Thermodynamics(
-        zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros
-    )
+        ### time and grid parameters
+        z_delta = 25 * si.m
+        z_max = 3200 * si.m
+        timestep = 0.25 / 2 * si.s
+        time_end = 15 * si.minutes
 
-    ### microphysics scheme to use (within a wrapper)
-    nvec = 1
-    ke = 128
-    ivstart = 0
-    dz = np.array([25], dtype=np.float64)
-    qnc = 500
+        ### initial thermodynamic conditions
+        assert z_max % z_delta == 0, "z limit is not a multiple of the grid spacing."
+        zeros = np.zeros(int(z_max / z_delta))
+        thermo_init = Thermodynamics(
+            zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros
+        )
 
-    ### Call graupel
-    microphys_scheme = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
+        ### microphysics scheme to use (within a wrapper)
+        nvec = 1
+        ke = 128
+        ivstart = 0
+        dz = np.array([25], dtype=np.float64)
+        qnc = 500
 
-    ### Perform test of 1-D KiD rainshaft model using chosen setup
-    perform_1dkid_test_case(
-        z_delta,
-        z_max,
-        time_end,
-        timestep,
-        thermo_init,
-        microphys_scheme,
-        binpath,
-        run_name,
-    )
+        ### Call graupel
+        microphys_scheme = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
+
+        ### Perform test of 1-D KiD rainshaft model using chosen setup
+        perform_1dkid_test_case(
+            z_delta,
+            z_max,
+            time_end,
+            timestep,
+            thermo_init,
+            microphys_scheme,
+            binpath,
+            run_name,
+        )

--- a/tests/test_icon_satadj_microphysics_scheme.py
+++ b/tests/test_icon_satadj_microphysics_scheme.py
@@ -1,0 +1,88 @@
+"""
+Copyright (c) 2024 MPI-M, Clara Bayley
+
+----- Microphysics Test Cases -----
+File: test_mock_py_microphysics_scheme.py
+Project: tests
+Created Date: Tuesday 27th February 2024
+Author: Clara Bayley (CB)
+Additional Contributors:
+-----
+Last Modified: Monday 11th November 2024
+Modified By: CB
+-----
+License: BSD 3-Clause "New" or "Revised" License
+https://opensource.org/licenses/BSD-3-Clause
+-----
+File Description:
+mock unit tests for Python microphysics module
+"""
+
+import numpy as np
+from copy import deepcopy
+
+from libs.icon_satadj.microphysics_scheme_wrapper import MicrophysicsSchemeWrapper, py_graupel
+from libs.thermo.thermodynamics import Thermodynamics
+
+def test_initialize_wrapper():
+    nvec = 1
+    ke = 1
+    ivstart = 0
+    dz = np.array([10], dtype=np.float64)
+    qnc = 500
+    microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
+
+    assert microphys_wrapped.initialize() == 0
+
+
+def test_finalize_wrapper():
+    nvec = 1
+    ke = 1
+    ivstart = 0
+    dz = np.array([10], dtype=np.float64)
+    qnc = 500
+    microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
+
+    assert microphys_wrapped.finalize() == 0
+
+
+def test_microphys_with_wrapper():
+    nvec = 1
+    ke = 1
+    ivstart = 0
+    dz = np.array([10], dtype=np.float64)
+    qnc = 500
+    microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
+
+    timestep = 1.0
+    temp = np.array([288.15], dtype=np.float64)
+    rho = np.array([1.225], dtype=np.float64)
+    press = np.array([101325], dtype=np.float64)
+    qvap = np.array([0.015], dtype=np.float64)
+    qcond = np.array([0.0001], dtype=np.float64)
+    qice = np.array([0.0002], dtype=np.float64)
+    qrain = np.array([0.0003], dtype=np.float64)
+    qsnow = np.array([0.0004], dtype=np.float64)
+    qgrau = np.array([0.0005], dtype=np.float64)
+
+    thermo = Thermodynamics(temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau)
+
+    # temporary variable
+    total_ice = qgrau + qsnow + qice
+      
+    # call saturation adjustment
+    py_graupel.saturation_adjustment(
+        ncells=nvec,
+        nlev=ke,
+        ta=temp,
+        qv=qvap,
+        qc=qcond,
+        qr=qrain,
+        total_ice=total_ice,
+        rho=rho,
+    )
+       
+    result = microphys_wrapped.run(timestep, thermo)
+
+    assert result.temp == temp  
+    assert result.massmix_ratios == [qvap, qcond, qice, qrain, qsnow, qgrau]

--- a/tests/test_icon_satadj_microphysics_scheme.py
+++ b/tests/test_icon_satadj_microphysics_scheme.py
@@ -19,10 +19,13 @@ mock unit tests for Python microphysics module
 """
 
 import numpy as np
-from copy import deepcopy
 
-from libs.icon_satadj.microphysics_scheme_wrapper import MicrophysicsSchemeWrapper, py_graupel
+from libs.icon_satadj.microphysics_scheme_wrapper import (
+    MicrophysicsSchemeWrapper,
+    py_graupel,
+)
 from libs.thermo.thermodynamics import Thermodynamics
+
 
 def test_initialize_wrapper():
     nvec = 1
@@ -69,7 +72,7 @@ def test_microphys_with_wrapper():
 
     # temporary variable
     total_ice = qgrau + qsnow + qice
-      
+
     # call saturation adjustment
     py_graupel.saturation_adjustment(
         ncells=nvec,
@@ -81,8 +84,8 @@ def test_microphys_with_wrapper():
         total_ice=total_ice,
         rho=rho,
     )
-       
+
     result = microphys_wrapped.run(timestep, thermo)
 
-    assert result.temp == temp  
+    assert result.temp == temp
     assert result.massmix_ratios == [qvap, qcond, qice, qrain, qsnow, qgrau]

--- a/tests/test_icon_satadj_microphysics_scheme.py
+++ b/tests/test_icon_satadj_microphysics_scheme.py
@@ -19,73 +19,75 @@ mock unit tests for Python microphysics module
 """
 
 import numpy as np
+import os
 
-from libs.icon_satadj.microphysics_scheme_wrapper import (
-    MicrophysicsSchemeWrapper,
-    py_graupel,
-)
-from libs.thermo.thermodynamics import Thermodynamics
-
-
-def test_initialize_wrapper():
-    nvec = 1
-    ke = 1
-    ivstart = 0
-    dz = np.array([10], dtype=np.float64)
-    qnc = 500
-    microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
-
-    assert microphys_wrapped.initialize() == 0
-
-
-def test_finalize_wrapper():
-    nvec = 1
-    ke = 1
-    ivstart = 0
-    dz = np.array([10], dtype=np.float64)
-    qnc = 500
-    microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
-
-    assert microphys_wrapped.finalize() == 0
-
-
-def test_microphys_with_wrapper():
-    nvec = 1
-    ke = 1
-    ivstart = 0
-    dz = np.array([10], dtype=np.float64)
-    qnc = 500
-    microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
-
-    timestep = 1.0
-    temp = np.array([288.15], dtype=np.float64)
-    rho = np.array([1.225], dtype=np.float64)
-    press = np.array([101325], dtype=np.float64)
-    qvap = np.array([0.015], dtype=np.float64)
-    qcond = np.array([0.0001], dtype=np.float64)
-    qice = np.array([0.0002], dtype=np.float64)
-    qrain = np.array([0.0003], dtype=np.float64)
-    qsnow = np.array([0.0004], dtype=np.float64)
-    qgrau = np.array([0.0005], dtype=np.float64)
-
-    thermo = Thermodynamics(temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau)
-
-    # temporary variable
-    total_ice = qgrau + qsnow + qice
-
-    # call saturation adjustment
-    py_graupel.saturation_adjustment(
-        ncells=nvec,
-        nlev=ke,
-        ta=temp,
-        qv=qvap,
-        qc=qcond,
-        qr=qrain,
-        total_ice=total_ice,
-        rho=rho,
+path = os.environ.get("PY_GRAUPEL_DIR")
+if path and path is not None:
+    from libs.icon_satadj.microphysics_scheme_wrapper import (
+        MicrophysicsSchemeWrapper,
+        py_graupel,
     )
+    from libs.thermo.thermodynamics import Thermodynamics
 
-    result = microphys_wrapped.run(timestep, thermo)
+    def test_initialize_wrapper():
+        nvec = 1
+        ke = 1
+        ivstart = 0
+        dz = np.array([10], dtype=np.float64)
+        qnc = 500
+        microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 
-    assert result.temp == temp
-    assert result.massmix_ratios == [qvap, qcond, qice, qrain, qsnow, qgrau]
+        assert microphys_wrapped.initialize() == 0
+
+    def test_finalize_wrapper():
+        nvec = 1
+        ke = 1
+        ivstart = 0
+        dz = np.array([10], dtype=np.float64)
+        qnc = 500
+        microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
+
+        assert microphys_wrapped.finalize() == 0
+
+    def test_microphys_with_wrapper():
+        nvec = 1
+        ke = 1
+        ivstart = 0
+        dz = np.array([10], dtype=np.float64)
+        qnc = 500
+        microphys_wrapped = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
+
+        timestep = 1.0
+        temp = np.array([288.15], dtype=np.float64)
+        rho = np.array([1.225], dtype=np.float64)
+        press = np.array([101325], dtype=np.float64)
+        qvap = np.array([0.015], dtype=np.float64)
+        qcond = np.array([0.0001], dtype=np.float64)
+        qice = np.array([0.0002], dtype=np.float64)
+        qrain = np.array([0.0003], dtype=np.float64)
+        qsnow = np.array([0.0004], dtype=np.float64)
+        qgrau = np.array([0.0005], dtype=np.float64)
+
+        thermo = Thermodynamics(
+            temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
+        )
+
+        # temporary variable
+        total_ice = qgrau + qsnow + qice
+
+        # call saturation adjustment
+        py_graupel.saturation_adjustment(
+            ncells=nvec,
+            nlev=ke,
+            ta=temp,
+            qv=qvap,
+            qc=qcond,
+            qr=qrain,
+            total_ice=total_ice,
+            rho=rho,
+        )
+
+        result = microphys_wrapped.run(timestep, thermo)
+
+        assert result.temp == temp
+        assert result.massmix_ratios == [qvap, qcond, qice, qrain, qsnow, qgrau]


### PR DESCRIPTION
- add pytests for ICON microphysics without graupel i.e. only one-moment bulk scheme's saturation adjustment
- adds some more variables to 0-D parcel plots