### PR TITLE
correct tests for CLEO 1-D KiD

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -158,13 +158,23 @@ jobs:
       - name: Download CLEO Initial Condition Files for 1-D KiD Test
         run: |
           mkdir -p ./src/cleo_initial_conditions/1dkid/
-          curl https://swift.dkrz.de/v1/dkrz_8f1b1e92-f07c-41c5-a4ae-8089ec495d87/microphysics_testcases/src/cleo_initial_conditions/1dkid/config.yaml \
-            -o src/cleo_initial_conditions/1dkid/config.yaml
-          curl https://swift.dkrz.de/v1/dkrz_8f1b1e92-f07c-41c5-a4ae-8089ec495d87/microphysics_testcases/src/cleo_initial_conditions/1dkid/dimlessGBxboundaries.dat \
-            -o src/cleo_initial_conditions/1dkid/dimlessGBxboundaries.dat
-          curl https://swift.dkrz.de/v1/dkrz_8f1b1e92-f07c-41c5-a4ae-8089ec495d87/microphysics_testcases/src/cleo_initial_conditions/1dkid/dimlessSDsinit.dat \
-            -o src/cleo_initial_conditions/1dkid/dimlessSDsinit.dat
+          mkdir -p ./src/cleo_initial_conditions/1dkid/condevap_only/
+          mkdir -p ./src/cleo_initial_conditions/1dkid/fullscheme/
+          curl https://swift.dkrz.de/v1/dkrz_8f1b1e92-f07c-41c5-a4ae-8089ec495d87/microphysics_testcases/src/cleo_initial_conditions/1dkid/condevap_only/config.yaml \
+            -o src/cleo_initial_conditions/1dkid/condevap_only/config.yaml
+          curl https://swift.dkrz.de/v1/dkrz_8f1b1e92-f07c-41c5-a4ae-8089ec495d87/microphysics_testcases/src/cleo_initial_conditions/1dkid/condevap_only/dimlessGBxboundaries.dat \
+            -o src/cleo_initial_conditions/1dkid/condevap_only/dimlessGBxboundaries.dat
+          curl https://swift.dkrz.de/v1/dkrz_8f1b1e92-f07c-41c5-a4ae-8089ec495d87/microphysics_testcases/src/cleo_initial_conditions/1dkid/condevap_only/dimlessSDsinit.dat \
+            -o src/cleo_initial_conditions/1dkid/condevap_only/dimlessSDsinit.dat
+          curl https://swift.dkrz.de/v1/dkrz_8f1b1e92-f07c-41c5-a4ae-8089ec495d87/microphysics_testcases/src/cleo_initial_conditions/1dkid/fullscheme/config.yaml \
+            -o src/cleo_initial_conditions/1dkid/fullscheme/config.yaml
+          curl https://swift.dkrz.de/v1/dkrz_8f1b1e92-f07c-41c5-a4ae-8089ec495d87/microphysics_testcases/src/cleo_initial_conditions/1dkid/fullscheme/dimlessGBxboundaries.dat \
+            -o src/cleo_initial_conditions/1dkid/fullscheme/dimlessGBxboundaries.dat
+          curl https://swift.dkrz.de/v1/dkrz_8f1b1e92-f07c-41c5-a4ae-8089ec495d87/microphysics_testcases/src/cleo_initial_conditions/1dkid/fullscheme/dimlessSDsinit.dat \
+            -o src/cleo_initial_conditions/1dkid/fullscheme/dimlessSDsinit.dat
           pwd && echo "ls ./src/cleo_initial_conditions/1dkid/" && ls ./src/cleo_initial_conditions/1dkid/
+          echo "ls ./src/cleo_initial_conditions/1dkid/condevap_only/" && ls ./src/cleo_initial_conditions/1dkid/condevap_only/
+          echo "ls ./src/cleo_initial_conditions/1dkid/fullscheme/" && ls ./src/cleo_initial_conditions/1dkid/fullscheme/
 
       - name: Test with pytest
         run: pytest ./tests

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build*
 bin
 *.dat
 *.patch
+*.png
 
 ##### Documentation Build Artifacts #####
 docs/source/_autosummary

--- a/extern/cleo/CMakeLists.txt
+++ b/extern/cleo/CMakeLists.txt
@@ -8,9 +8,9 @@ include(FetchContent)
 FetchContent_Declare(
   cleo
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-  URL https://github.com/yoctoyotta1024/CLEO/archive/refs/tags/v0.48.0.zip
-  GIT_TAG b38b9d116713a7ff80538798c60425b4b695f8f5
+  URL https://github.com/yoctoyotta1024/CLEO/archive/refs/tags/v0.49.0.zip
+  GIT_TAG 8c951ce785cf29c52f04f4e379fe444b3f92352b
 )
 FetchContent_MakeAvailable(cleo)
 
-message(STATUS "CLEO version v0.48.0, installation in: ${CLEO_BINARY_DIR}")
+message(STATUS "CLEO version v0.49.0, installation in: ${CLEO_BINARY_DIR}")

--- a/extern/cleo/CMakeLists.txt
+++ b/extern/cleo/CMakeLists.txt
@@ -8,9 +8,9 @@ include(FetchContent)
 FetchContent_Declare(
   cleo
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-  URL https://github.com/yoctoyotta1024/CLEO/archive/refs/tags/v0.45.0.zip
-  GIT_TAG 737964f8ea85914d7b73c28e0479d739fe2ea340
+  URL https://github.com/yoctoyotta1024/CLEO/archive/refs/tags/v0.47.0.zip
+  GIT_TAG 2691853256e7449f9d5bb1469e2c30fda1d3e429
 )
 FetchContent_MakeAvailable(cleo)
 
-message(STATUS "CLEO version v0.45.0, installation in: ${CLEO_BINARY_DIR}")
+message(STATUS "CLEO version v0.47.0, installation in: ${CLEO_BINARY_DIR}")

--- a/extern/cleo/CMakeLists.txt
+++ b/extern/cleo/CMakeLists.txt
@@ -8,9 +8,9 @@ include(FetchContent)
 FetchContent_Declare(
   cleo
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-  URL https://github.com/yoctoyotta1024/CLEO/archive/refs/tags/v0.47.0.zip
-  GIT_TAG 2691853256e7449f9d5bb1469e2c30fda1d3e429
+  URL https://github.com/yoctoyotta1024/CLEO/archive/refs/tags/v0.48.0.zip
+  GIT_TAG b38b9d116713a7ff80538798c60425b4b695f8f5
 )
 FetchContent_MakeAvailable(cleo)
 
-message(STATUS "CLEO version v0.47.0, installation in: ${CLEO_BINARY_DIR}")
+message(STATUS "CLEO version v0.48.0, installation in: ${CLEO_BINARY_DIR}")

--- a/libs/cleo_sdm/cleo_sdm.py
+++ b/libs/cleo_sdm/cleo_sdm.py
@@ -58,10 +58,12 @@ def create_sdm(config, tsteps, is_motion):
 
     if is_motion:
         print("PYCLEO STATUS: creating Superdroplet Movement")
-        motion = pycleo.create_cartesian_predcorr_motion(tsteps.get_motionstep())
+        motion = pycleo.create_cartesian_predcorr_motion(
+            config, tsteps.get_motionstep()
+        )
     else:
         print("PYCLEO STATUS: creating Superdroplet Movement without Motion")
-        motion = pycleo.create_cartesian_predcorr_motion(False)
+        motion = pycleo.create_cartesian_predcorr_motion(config, False)
     transport = pycleo.CartesianTransportAcrossDomain()
     boundary_conditions = pycleo.NullBoundaryConditions()
     move = pycleo.CartesianMoveSupersInDomain(motion, transport, boundary_conditions)

--- a/libs/cleo_sdm/cleo_sdm.py
+++ b/libs/cleo_sdm/cleo_sdm.py
@@ -8,7 +8,7 @@ Created Date: Monday 23rd June 2025
 Author: Clara Bayley (CB)
 Additional Contributors:
 -----
-Last Modified: Tuesday 1st July 2025
+Last Modified: Thursday 10th July 2025
 Modified By: CB
 -----
 License: BSD 3-Clause "New" or "Revised" License
@@ -104,7 +104,17 @@ class CleoSDM:
         temp,
         qvap,
         qcond,
+        wvel,
+        uvel,
+        vvel,
     ):
+        """Initialize the CleoSDM object.
+
+        CleoSDM class only works correctly if addresses of press, temp,
+        qvap, qcond, wvel, uvel, and vvel arrays remain unchanged throughout a simulation.
+        Undefined behaviour if values are changed by reassigning arrays rather than by copying
+        data into the arrays given during class initialisation.
+        """
         self.name = "CLEO SDM microphysics"
 
         tsteps = pycleo.pycreate_timesteps(config)
@@ -122,6 +132,9 @@ class CleoSDM:
             temp,
             qvap,
             qcond,
+            wvel,
+            uvel,
+            vvel,
         )
         self.comms = coupldyn_numpy.NumpyComms()
 

--- a/libs/cleo_sdm/cleo_sdm.py
+++ b/libs/cleo_sdm/cleo_sdm.py
@@ -150,7 +150,7 @@ class CleoSDM:
             self.t_sdm
         ), "SDM out of sync with coupling"
 
-        print(f"PYCLEO STATUS: start t_sdm = {self.t_sdm} [model timesteps]")
+        # print(f"PYCLEO STATUS: start t_sdm = {self.t_sdm} [model timesteps]")
         while self.t_sdm < t_mdl_next:
             t_sdm_next = min(
                 self.sdm.next_couplstep(self.t_sdm), self.sdm.obs.next_obs(self.t_sdm)
@@ -169,4 +169,4 @@ class CleoSDM:
                 self.comms.send_dynamics(self.sdm.gbxmaps, self.gbxs, self.coupldyn)
 
             self.t_sdm = t_sdm_next
-        print(f"PYCLEO STATUS: end t_sdm = {self.t_sdm} [model timesteps]")
+        # print(f"PYCLEO STATUS: end t_sdm = {self.t_sdm} [model timesteps]")

--- a/libs/cleo_sdm/microphysics_scheme_wrapper.py
+++ b/libs/cleo_sdm/microphysics_scheme_wrapper.py
@@ -62,10 +62,6 @@ class MicrophysicsSchemeWrapper:
         Undefined behaviour if values are changed by reassigning arrays rather than by copying
         data into the arrays given during wrapper initialisation.
         """
-        self.wvel = wvel
-        self.uvel = uvel
-        self.vvel = vvel
-
         config = pycleo.Config(str(config_filename))
         pycleo.pycleo_initialize(config)
 
@@ -130,17 +126,17 @@ class MicrophysicsSchemeWrapper:
         # de-dimensionlise variables
         thermo.press /= self.P0
         thermo.temp /= self.TEMP0
-        self.wvel /= self.W0
-        self.uvel /= self.W0
-        self.vvel /= self.W0
+        thermo.wvel /= self.W0
+        thermo.uvel /= self.W0
+        thermo.vvel /= self.W0
 
         self.microphys.run(timestep)
 
         # re-dimensionlise variables
         thermo.press *= self.P0
         thermo.temp *= self.TEMP0
-        self.wvel *= self.W0
-        self.uvel *= self.W0
-        self.vvel *= self.W0
+        thermo.wvel *= self.W0
+        thermo.uvel *= self.W0
+        thermo.vvel *= self.W0
 
         return thermo

--- a/libs/cleo_sdm/microphysics_scheme_wrapper.py
+++ b/libs/cleo_sdm/microphysics_scheme_wrapper.py
@@ -51,19 +51,43 @@ class MicrophysicsSchemeWrapper:
         temp,
         qvap,
         qcond,
+        wvel,
+        uvel,
+        vvel,
     ):
-        """Initialize the MicrophysicsSchemeWrapper object."""
+        """Initialize the MicrophysicsSchemeWrapper object.
+
+        This Wrapper only works correctly if addresses of press, temp,
+        qvap, qcond, wvel, uvel, and vvel arrays remain unchanged throughout a simulation.
+        Undefined behaviour if values are changed by reassigning arrays rather than by copying
+        data into the arrays given during wrapper initialisation.
+        """
+        self.wvel = wvel
+        self.uvel = uvel
+        self.vvel = vvel
+
         config = pycleo.Config(str(config_filename))
         pycleo.pycleo_initialize(config)
 
         self.microphys = CleoSDM(
-            config, is_motion, t_start, timestep, press, temp, qvap, qcond
+            config,
+            is_motion,
+            t_start,
+            timestep,
+            press,
+            temp,
+            qvap,
+            qcond,
+            wvel,
+            uvel,
+            vvel,
         )
         self.name = "Wrapper around " + self.microphys.name
 
         # constants to de-dimensionalise thermodynamics
         self.TEMP0 = 273.15  # Temperature [K]
         self.P0 = 100000.0  # Pressure [Pa]
+        self.W0 = 1.0  # Velocity [m/s]
 
     def initialize(self) -> int:
         """Initialise the microphysics scheme.
@@ -106,11 +130,17 @@ class MicrophysicsSchemeWrapper:
         # de-dimensionlise variables
         thermo.press /= self.P0
         thermo.temp /= self.TEMP0
+        self.wvel /= self.W0
+        self.uvel /= self.W0
+        self.vvel /= self.W0
 
         self.microphys.run(timestep)
 
         # re-dimensionlise variables
         thermo.press *= self.P0
         thermo.temp *= self.TEMP0
+        self.wvel *= self.W0
+        self.uvel *= self.W0
+        self.vvel *= self.W0
 
         return thermo

--- a/libs/test_case_0dparcel/adiabatic_motion.py
+++ b/libs/test_case_0dparcel/adiabatic_motion.py
@@ -201,6 +201,15 @@ class AdiabaticMotion:
         assert (
             thermo.massmix_ratios["qvap"].size == 1
         ), "AdiabaticMotion only applicable to 0-D parcel (1 element)"
+        assert (thermo.wvel.size == 2) or (
+            thermo.wvel.size == 0
+        ), "AdiabaticMotion only applicable to 0-D parcel (1 element)"
+        assert (thermo.uvel.size == 2) or (
+            thermo.uvel.size == 0
+        ), "AdiabaticMotion only applicable to 0-D parcel (1 element)"
+        assert (thermo.vvel.size == 2) or (
+            thermo.vvel.size == 0
+        ), "AdiabaticMotion only applicable to 0-D parcel (1 element)"
 
         t0, t1 = time, time + timestep
         qvap = thermo.massmix_ratios["qvap"][0]

--- a/libs/test_case_1dkid/kid_dynamics.py
+++ b/libs/test_case_1dkid/kid_dynamics.py
@@ -37,7 +37,7 @@ class KiDDynamics:
     for the original source code.
     """
 
-    def __init__(self, z_delta, z_max, timestep, t_end):
+    def __init__(self, z_delta, z_max, timestep, t_end, advect_hydrometeors=True):
         """Initialize the KiDDynamics object.
 
         Args:
@@ -66,6 +66,8 @@ class KiDDynamics:
             g_factor_of_zZ=lambda zZ: self.settings.rhod(zZ * self.settings.dz),
             options=options,
         )
+
+        self.advect_hydrometeors = advect_hydrometeors
 
         assert self.settings.nz == int(z_max / z_delta)
         assert self.settings.dz == z_delta
@@ -131,7 +133,12 @@ class KiDDynamics:
         )
         advector_0 = np.ones_like(self.settings.z_vec) * GC
 
-        for field in self.mpdata.fields:
+        if self.advect_hydrometeors:
+            for field in self.mpdata.fields:
+                self.mpdata[field].advector.get_component(0)[:] = advector_0
+                self.mpdata[field].advance(1)
+        else:
+            field = "qvap"
             self.mpdata[field].advector.get_component(0)[:] = advector_0
             self.mpdata[field].advance(1)
 

--- a/libs/test_case_1dkid/kid_dynamics.py
+++ b/libs/test_case_1dkid/kid_dynamics.py
@@ -48,12 +48,14 @@ class KiDDynamics:
         """
         options = Options(n_iters=3, nonoscillatory=True)
 
-        RHOD_VERTVELO = 3 * si.m / si.s * si.kg / si.m**3
+        WMAX = 3  # maximum vertical velocity [m/s], 'w1' of equation (6) in Shipway and Hill (2012)
+        TSCALE = 600  # timescale of sinusoid [s], 't1' of equation (6) in Shipway and Hill (2012)
         P0 = 1007 * si.hPa
         self.settings = Settings(
             dt=timestep,
             dz=z_delta,
-            rhod_w_const=RHOD_VERTVELO,
+            wmax_const=WMAX,
+            tscale_const=TSCALE,
             t_max=t_end,
             p0=P0,
             z_max=z_max,

--- a/libs/test_case_1dkid/kid_dynamics.py
+++ b/libs/test_case_1dkid/kid_dynamics.py
@@ -124,7 +124,9 @@ class KiDDynamics:
         thermo.massmix_ratios["qsnow"][:] = self.mpdata["qsnow"].advectee.get()
         thermo.massmix_ratios["qgrau"][:] = self.mpdata["qgrau"].advectee.get()
 
-        wmagnitude = self.updraught_velocity.magnitude(time)
+        wmagnitude = self.updraught_velocity.magnitude(
+            time
+        )  # TODO(CB: get from mpdata directly
         thermo.wvel[:] = np.ones_like(thermo.wvel) * wmagnitude
 
         return thermo

--- a/libs/test_case_1dkid/perform_1dkid_test_case.py
+++ b/libs/test_case_1dkid/perform_1dkid_test_case.py
@@ -29,7 +29,15 @@ from libs.thermo import formulae
 
 
 def perform_1dkid_test_case(
-    z_delta, z_max, time_end, timestep, thermo_init, microphys_scheme, binpath, run_name
+    z_delta,
+    z_max,
+    time_end,
+    timestep,
+    thermo_init,
+    microphys_scheme,
+    advect_hydrometeors,
+    binpath,
+    run_name,
 ):
     """
     Run test case for a 1-D KiD rainshaft model.
@@ -57,7 +65,15 @@ def perform_1dkid_test_case(
     """
 
     print("\n--- Running 1-D KiD Rainshaft Model ---")
-    out = run_1dkid(z_delta, z_max, time_end, timestep, thermo_init, microphys_scheme)
+    out = run_1dkid(
+        z_delta,
+        z_max,
+        time_end,
+        timestep,
+        thermo_init,
+        microphys_scheme,
+        advect_hydrometeors,
+    )
     print("--------------------------------")
 
     print("--- Plotting Results ---")

--- a/libs/test_case_1dkid/run_1dkid.py
+++ b/libs/test_case_1dkid/run_1dkid.py
@@ -22,7 +22,9 @@ from .kid_dynamics import KiDDynamics
 from libs.thermo.output_thermodynamics import OutputThermodynamics
 
 
-def run_1dkid(z_delta, z_max, time_end, timestep, thermo, microphys_scheme):
+def run_1dkid(
+    z_delta, z_max, time_end, timestep, thermo, microphys_scheme, advect_hydrometeors
+):
     """Run 1-D KiD rainshaft model with a specified microphysics scheme and KiD dynamics.
 
     This function runs a 1-D KiD rainshaft model with the given initial
@@ -48,7 +50,9 @@ def run_1dkid(z_delta, z_max, time_end, timestep, thermo, microphys_scheme):
     """
 
     ### type of dynamics rainshaft will undergo
-    kid_dynamics = KiDDynamics(z_delta, z_max, timestep, time_end)
+    kid_dynamics = KiDDynamics(
+        z_delta, z_max, timestep, time_end, advect_hydrometeors=advect_hydrometeors
+    )
 
     ### run dynamics + microphysics from time to time_end
     microphys_scheme.initialize()

--- a/libs/test_case_1dkid/run_1dkid.py
+++ b/libs/test_case_1dkid/run_1dkid.py
@@ -64,7 +64,7 @@ def run_1dkid(
     out = OutputThermodynamics(shape, zhalf=kid_dynamics.zhalf)
 
     time = 0.0
-    thermo = kid_dynamics.set_thermo(thermo)
+    thermo = kid_dynamics.set_thermo(time, thermo)
     out.output_thermodynamics(time, thermo)
     while time < time_end:
         thermo = kid_dynamics.run(time, timestep, thermo)

--- a/libs/test_case_1dkid/settings.py
+++ b/libs/test_case_1dkid/settings.py
@@ -39,7 +39,8 @@ class Settings:
         self,
         dt: float,
         dz: float,
-        rhod_w_const: float,
+        wmax_const: float,
+        tscale_const: float,
         t_max: float = 15 * si.minutes,
         p0: Optional[float] = None,
         z_max: float = 3000 * si.metres,
@@ -82,7 +83,8 @@ class Settings:
 
         self.rhod = interp1d(z_points, rhod_solution.y[0])
 
-        self.t_1 = 600 * si.s
+        rhod_w_const = wmax_const * si.m / si.s * si.kg / si.m**3
+        self.t_1 = tscale_const * si.s
         self.rhod_w = lambda t: (
             rhod_w_const * np.sin(np.pi * t / self.t_1) if t < self.t_1 else 0
         )

--- a/libs/thermo/thermodynamics.py
+++ b/libs/thermo/thermodynamics.py
@@ -79,6 +79,9 @@ class Thermodynamics:
         qrain: np.ndarray,
         qsnow: np.ndarray,
         qgrau: np.ndarray,
+        wvel: np.ndarray,
+        uvel: np.ndarray,
+        vvel: np.ndarray,
     ):
         """Initialize a thermodynamics object with the given variables
 
@@ -92,7 +95,9 @@ class Thermodynamics:
             qrain (np.ndarray): Specific rain content (kg/kg)
             qsnow (np.ndarray): Specific snow content kg/kg)
             qgrau (np.ndarray): Specific graupel content (kg/kg)
-
+            wvel (np.ndarray): vertical wind velocity, 'z', (m/s)
+            uvel (np.ndarray): zonal wind velocity, 'x', (m/s)
+            vvel (np.ndarray): meridional wind velocity, 'y', (m/s)
         """
         self.temp = deepcopy(temp)
         self.rho = deepcopy(rho)
@@ -105,6 +110,9 @@ class Thermodynamics:
             "qsnow": deepcopy(qsnow),
             "qgrau": deepcopy(qgrau),
         }
+        self.wvel = deepcopy(wvel)
+        self.uvel = deepcopy(uvel)
+        self.vvel = deepcopy(vvel)
 
     def print_state(self):
         print(self.temp)

--- a/scripts/using_microphysics_scheme_example.py
+++ b/scripts/using_microphysics_scheme_example.py
@@ -76,7 +76,12 @@ def main():
     qrain = np.array([0.0], dtype=np.float64)
     qsnow = np.array([0.0], dtype=np.float64)
     qgrau = np.array([0.0], dtype=np.float64)
-    thermo = Thermodynamics(temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau)
+    wvel = np.array([])  # this microphysics scheme doesn't need thermodynamics' winds
+    uvel = np.array([])  # this microphysics scheme doesn't need thermodynamics' winds
+    vvel = np.array([])  # this microphysics scheme doesn't need thermodynamics' winds
+    thermo = Thermodynamics(
+        temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau, wvel, uvel, vvel
+    )
 
     nvec = 1
     ke = 1

--- a/src/cleo_initial_conditions/0dparcel/config.yaml
+++ b/src/cleo_initial_conditions/0dparcel/config.yaml
@@ -61,3 +61,7 @@ microphysics:
     MINSUBTSTEP: 0.001                                     # minimum subtimestep in cases of substepping [s]
     rtol: 0.0                                              # relative tolerance for implicit Euler integration
     atol: 0.01                                             # absolute tolerance for implicit Euler integration
+
+### Pycleo (Python Bindings) Parameters ###
+pycleo:
+  enable_condensation : true                               # true enables condensation in microphysics

--- a/src/cleo_initial_conditions/1dkid/condevap_only/config.yaml
+++ b/src/cleo_initial_conditions/1dkid/condevap_only/config.yaml
@@ -33,7 +33,7 @@ domain:
   maxnsupers: 1024                                     # maximum number of SDs
 
 timesteps:
-  CONDTSTEP : 1.25                                      # time between SD condensation [s]
+  CONDTSTEP : 0.1                                       # time between SD condensation [s]
   COLLTSTEP : 1.25                                      # time between SD collision [s]
   MOTIONTSTEP : 1.25                                    # time between SDM motion [s]
   COUPLTSTEP : 1.25                                     # time between dynamic couplings [s]

--- a/src/cleo_initial_conditions/1dkid/condevap_only/config.yaml
+++ b/src/cleo_initial_conditions/1dkid/condevap_only/config.yaml
@@ -1,0 +1,65 @@
+---
+# ----- CLEO -----
+# File: config.yaml
+# Project: config
+# Created Date: Friday 27th June 2025
+# Author: Clara Bayley (CB)
+# Additional Contributors:
+# -----
+# Last Modified: Friday 27th June 2025
+# Modified By: CB
+# -----
+# License: BSD 3-Clause "New" or "Revised" License
+# https://opensource.org/licenses/BSD-3-Clause
+# -----
+# Copyright (c) 2023 MPI-M, Clara Bayley
+# -----
+# File Description:
+# Configuration file for CLEO SDM coupled to a dynamics solver.
+# Note: The initial superdroplets data read from file "initsupers_filename" can be made with
+# CLEO's pySD module (see Python script "create_initsuperdropsbinary_script.py" for usage).
+# Likewise the "grid_filename" can be made using pySD (see "create_gbxboundariesbinary_script.py"),
+# and so can the thermodynamics files when using coupled thermodynamics "fromfile".
+#
+
+### Kokkos Initialization Parameters ###
+kokkos_settings:
+  num_threads : 64                                     # number of threads for host parallel backend
+
+### SDM Runtime Parameters ###
+domain:
+  nspacedims : 1                                       # no. of spatial dimensions to model
+  ngbxs : 128                                          # total number of Gbxs
+  maxnsupers: 1024                                     # maximum number of SDs
+
+timesteps:
+  CONDTSTEP : 1.25                                      # time between SD condensation [s]
+  COLLTSTEP : 1.25                                      # time between SD collision [s]
+  MOTIONTSTEP : 1.25                                    # time between SDM motion [s]
+  COUPLTSTEP : 1.25                                     # time between dynamic couplings [s]
+  OBSTSTEP : 900                                        # time between SDM observations [s]
+  T_END : 900                                           # time span of integration from 0s to T_END [s]
+
+### Initialisation Parameters ###
+inputfiles:
+  constants_filename : ./build/_deps/cleo-src/libs/cleoconstants.hpp  # name of file for values of physical constants
+  grid_filename : ./src/cleo_initial_conditions/1dkid/condevap_only/dimlessGBxboundaries.dat  # binary filename for initialisation of GBxs / GbxMaps
+
+initsupers:
+  type: frombinary                                     # type of initialisation of super-droplets
+  initsupers_filename : ./src/cleo_initial_conditions/1dkid/condevap_only/dimlessSDsinit.dat  # binary filename for initialisation of SDs
+
+### Output Parameters ###
+outputdata:
+  setup_filename : ./build/bin/1dkid_condevap_only_setup.txt     # .txt filename to copy configuration to
+  zarrbasedir : ./build/bin/1dkid_condevap_only_sol.zarr  # zarr store base directory
+  maxchunk : 2500000                         # maximum no. of elements in chunks of zarr store array
+
+### Microphysics Parameters ###
+microphysics:
+  condensation:
+    do_alter_thermo : true                             # true = cond/evap alters the thermodynamic state
+    maxniters : 50                                     # maximum no. iterations of Newton Raphson Method
+    MINSUBTSTEP : 0.01                                 # minimum subtimestep in cases of substepping [s]
+    rtol : 0.0                                         # relative tolerance for implicit Euler integration
+    atol : 0.001                                       # absolute tolerance for implicit Euler integration

--- a/src/cleo_initial_conditions/1dkid/condevap_only/config.yaml
+++ b/src/cleo_initial_conditions/1dkid/condevap_only/config.yaml
@@ -60,7 +60,7 @@ microphysics:
   condensation:
     do_alter_thermo : true                             # true = cond/evap alters the thermodynamic state
     maxniters : 50                                     # maximum no. iterations of Newton Raphson Method
-    MINSUBTSTEP : 0.01                                 # minimum subtimestep in cases of substepping [s]
+    MINSUBTSTEP : 0.005                                # minimum subtimestep in cases of substepping [s]
     rtol : 0.0                                         # relative tolerance for implicit Euler integration
     atol : 0.001                                       # absolute tolerance for implicit Euler integration
 

--- a/src/cleo_initial_conditions/1dkid/condevap_only/config.yaml
+++ b/src/cleo_initial_conditions/1dkid/condevap_only/config.yaml
@@ -63,3 +63,9 @@ microphysics:
     MINSUBTSTEP : 0.01                                 # minimum subtimestep in cases of substepping [s]
     rtol : 0.0                                         # relative tolerance for implicit Euler integration
     atol : 0.001                                       # absolute tolerance for implicit Euler integration
+
+### Pycleo (Python Bindings) Parameters ###
+pycleo:
+  enable_terminal_velocity : false                                 # true enables terminal velocity in superdroplet motion
+  enable_condensation : true                                       # true enables condensation in microphysics
+  enable_collisions : false                                        # true enables collisions in microphysics

--- a/src/cleo_initial_conditions/1dkid/fullscheme/config.yaml
+++ b/src/cleo_initial_conditions/1dkid/fullscheme/config.yaml
@@ -33,7 +33,7 @@ domain:
   maxnsupers: 1024                                     # maximum number of SDs
 
 timesteps:
-  CONDTSTEP : 1.25                                      # time between SD condensation [s]
+  CONDTSTEP : 0.1                                       # time between SD condensation [s]
   COLLTSTEP : 1.25                                      # time between SD collision [s]
   MOTIONTSTEP : 1.25                                    # time between SDM motion [s]
   COUPLTSTEP : 1.25                                     # time between dynamic couplings [s]

--- a/src/cleo_initial_conditions/1dkid/fullscheme/config.yaml
+++ b/src/cleo_initial_conditions/1dkid/fullscheme/config.yaml
@@ -43,16 +43,16 @@ timesteps:
 ### Initialisation Parameters ###
 inputfiles:
   constants_filename : ./build/_deps/cleo-src/libs/cleoconstants.hpp  # name of file for values of physical constants
-  grid_filename : ./src/cleo_initial_conditions/1dkid/dimlessGBxboundaries.dat  # binary filename for initialisation of GBxs / GbxMaps
+  grid_filename : ./src/cleo_initial_conditions/1dkid/fullscheme/dimlessGBxboundaries.dat  # binary filename for initialisation of GBxs / GbxMaps
 
 initsupers:
   type: frombinary                                     # type of initialisation of super-droplets
-  initsupers_filename : ./src/cleo_initial_conditions/1dkid/dimlessSDsinit.dat  # binary filename for initialisation of SDs
+  initsupers_filename : ./src/cleo_initial_conditions/1dkid/fullscheme/dimlessSDsinit.dat  # binary filename for initialisation of SDs
 
 ### Output Parameters ###
 outputdata:
-  setup_filename : ./build/bin/1dkid_setup.txt     # .txt filename to copy configuration to
-  zarrbasedir : ./build/bin/1dkid_sol.zarr  # zarr store base directory
+  setup_filename : ./build/bin/1dkid_fullscheme_setup.txt     # .txt filename to copy configuration to
+  zarrbasedir : ./build/bin/1dkid_fullscheme_sol.zarr  # zarr store base directory
   maxchunk : 2500000                         # maximum no. of elements in chunks of zarr store array
 
 ### Microphysics Parameters ###

--- a/src/cleo_initial_conditions/1dkid/fullscheme/config.yaml
+++ b/src/cleo_initial_conditions/1dkid/fullscheme/config.yaml
@@ -60,7 +60,7 @@ microphysics:
   condensation:
     do_alter_thermo : true                             # true = cond/evap alters the thermodynamic state
     maxniters : 50                                     # maximum no. iterations of Newton Raphson Method
-    MINSUBTSTEP : 0.01                                 # minimum subtimestep in cases of substepping [s]
+    MINSUBTSTEP : 0.005                                # minimum subtimestep in cases of substepping [s]
     rtol : 0.0                                         # relative tolerance for implicit Euler integration
     atol : 0.001                                       # absolute tolerance for implicit Euler integration
 

--- a/src/cleo_initial_conditions/1dkid/fullscheme/config.yaml
+++ b/src/cleo_initial_conditions/1dkid/fullscheme/config.yaml
@@ -63,3 +63,9 @@ microphysics:
     MINSUBTSTEP : 0.01                                 # minimum subtimestep in cases of substepping [s]
     rtol : 0.0                                         # relative tolerance for implicit Euler integration
     atol : 0.001                                       # absolute tolerance for implicit Euler integration
+
+### Pycleo (Python Bindings) Parameters ###
+pycleo:
+  enable_terminal_velocity : true                                 # true enables terminal velocity in superdroplet motion
+  enable_condensation : true                                       # true enables condensation in microphysics
+  enable_collisions : true                                        # true enables collisions in microphysics

--- a/src/cleo_initial_conditions/generic/config.yaml
+++ b/src/cleo_initial_conditions/generic/config.yaml
@@ -59,3 +59,9 @@ outputdata:
   setup_filename : ./build/bin/setup.txt     # .txt filename to copy configuration to
   zarrbasedir : ./build/bin/sol.zarr  # zarr store base directory
   maxchunk : 2500000                         # maximum no. of elements in chunks of zarr store array
+
+### Pycleo (Python Bindings) Parameters ###
+pycleo:
+  enable_terminal_velocity : true                                  # true enables terminal velocity in superdroplet motion
+  enable_condensation : false                                      # true enables condensation in microphysics
+  enable_collisions : false                                        # true enables collisions in microphysics

--- a/src/cleo_initial_conditions/generic/config.yaml
+++ b/src/cleo_initial_conditions/generic/config.yaml
@@ -21,7 +21,7 @@
 #
 
 ### Python Binding Parameters ###
-pycleo_settings:
+pycleo_setup:
   is_motion : true                      # true/false, if true include superdroplet motion in SDM
 
 ### Kokkos Initialization Parameters ###

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,11 +58,20 @@ def pytest_addoption(parser):
         default=str(default_cleo_test_0dparcel_config_filename),
     )
 
-    default_cleo_test_1dkid_config_filename = (
-        Path.cwd() / "src" / "cleo_initial_conditions" / "1dkid" / "config.yaml"
+    cleo_initconds_1dkid_path = Path.cwd() / "src" / "cleo_initial_conditions" / "1dkid"
+    default_cleo_test_1dkid_condevap_only_config_filename = (
+        cleo_initconds_1dkid_path / "condevap_only" / "config.yaml"
+    )
+    default_cleo_test_1dkid_fullscheme_config_filename = (
+        cleo_initconds_1dkid_path / "fullscheme" / "config.yaml"
     )
     parser.addoption(
-        "--cleo_test_1dkid_config_filename",
+        "--cleo_test_1dkid_condevap_only_config_filename",
         action="store",
-        default=str(default_cleo_test_1dkid_config_filename),
+        default=str(default_cleo_test_1dkid_condevap_only_config_filename),
+    )
+    parser.addoption(
+        "--cleo_test_1dkid_fullscheme_config_filename",
+        action="store",
+        default=str(default_cleo_test_1dkid_fullscheme_config_filename),
     )

--- a/tests/test_case_0dparcel/test_cleo_sdm.py
+++ b/tests/test_case_0dparcel/test_cleo_sdm.py
@@ -94,6 +94,9 @@ def test_cleo_sdm_0dparcel(path2pycleo, config_filename):
     qrain = np.array([0.04], dtype=np.float64)
     qsnow = np.array([0.05], dtype=np.float64)
     qgrau = np.array([0.06], dtype=np.float64)
+    wvel = np.array([0.0, 0.0], dtype=np.float64)
+    uvel = np.array([0.0, 0.0], dtype=np.float64)
+    vvel = np.array([0.0, 0.0], dtype=np.float64)
     thermo_init = Thermodynamics(
         temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
     )
@@ -109,6 +112,9 @@ def test_cleo_sdm_0dparcel(path2pycleo, config_filename):
         thermo_init.temp,
         thermo_init.massmix_ratios["qvap"],
         thermo_init.massmix_ratios["qcond"],
+        wvel,
+        uvel,
+        vvel,
     )
 
     ### Perform 0-D parcel model test case using chosen setup

--- a/tests/test_case_0dparcel/test_cleo_sdm.py
+++ b/tests/test_case_0dparcel/test_cleo_sdm.py
@@ -98,7 +98,18 @@ def test_cleo_sdm_0dparcel(path2pycleo, config_filename):
     uvel = np.array([0.0, 0.0], dtype=np.float64)
     vvel = np.array([0.0, 0.0], dtype=np.float64)
     thermo_init = Thermodynamics(
-        temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
+        temp,
+        rho,
+        press,
+        qvap,
+        qcond,
+        qice,
+        qrain,
+        qsnow,
+        qgrau,
+        wvel,
+        uvel,
+        vvel,
     )
 
     ### microphysics scheme to use (within a wrapper)
@@ -112,9 +123,9 @@ def test_cleo_sdm_0dparcel(path2pycleo, config_filename):
         thermo_init.temp,
         thermo_init.massmix_ratios["qvap"],
         thermo_init.massmix_ratios["qcond"],
-        wvel,
-        uvel,
-        vvel,
+        thermo_init.wvel,
+        thermo_init.uvel,
+        thermo_init.vvel,
     )
 
     ### Perform 0-D parcel model test case using chosen setup

--- a/tests/test_case_0dparcel/test_icon_muphys.py
+++ b/tests/test_case_0dparcel/test_icon_muphys.py
@@ -106,8 +106,21 @@ def test_icon_muphys_0dparcel(aes_muphys_py_dir):
         qrain = np.array([0.04], dtype=np.float64)
         qsnow = np.array([0.0], dtype=np.float64)
         qgrau = np.array([0.0], dtype=np.float64)
+        wvel = uvel = vvel = np.array([])  # this microphysics test doesn't need winds
+
         thermo_init = Thermodynamics(
-            temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
+            temp,
+            rho,
+            press,
+            qvap,
+            qcond,
+            qice,
+            qrain,
+            qsnow,
+            qgrau,
+            wvel,
+            uvel,
+            vvel,
         )
 
         ### microphysics scheme to use (within a wrapper)

--- a/tests/test_case_0dparcel/test_icon_satadj.py
+++ b/tests/test_case_0dparcel/test_icon_satadj.py
@@ -105,8 +105,21 @@ def test_icon_satadj_0dparcel(aes_muphys_py_dir):
         qrain = np.array([0.04], dtype=np.float64)
         qsnow = np.array([0.0], dtype=np.float64)
         qgrau = np.array([0.0], dtype=np.float64)
+        wvel = uvel = vvel = np.array([])  # this microphysics test doesn't need winds
+
         thermo_init = Thermodynamics(
-            temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
+            temp,
+            rho,
+            press,
+            qvap,
+            qcond,
+            qice,
+            qrain,
+            qsnow,
+            qgrau,
+            wvel,
+            uvel,
+            vvel,
         )
 
         ### microphysics scheme to use (within a wrapper)

--- a/tests/test_case_0dparcel/test_mock_microphys.py
+++ b/tests/test_case_0dparcel/test_mock_microphys.py
@@ -82,8 +82,21 @@ def test_mock_0dparcel():
     qrain = np.array([0.04], dtype=np.float64)
     qsnow = np.array([0.05], dtype=np.float64)
     qgrau = np.array([0.06], dtype=np.float64)
+    wvel = uvel = vvel = np.array([])  # this microphysics test doesn't need winds
+
     thermo_init = Thermodynamics(
-        temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
+        temp,
+        rho,
+        press,
+        qvap,
+        qcond,
+        qice,
+        qrain,
+        qsnow,
+        qgrau,
+        wvel,
+        uvel,
+        vvel,
     )
 
     ### microphysics scheme to use (within a wrapper)

--- a/tests/test_case_0dparcel/test_pympdata_bulk.py
+++ b/tests/test_case_0dparcel/test_pympdata_bulk.py
@@ -78,8 +78,21 @@ def test_pympdata_bulk_0dparcel():
     qrain = np.array([0.04], dtype=np.float64)
     qsnow = np.array([0.05], dtype=np.float64)
     qgrau = np.array([0.06], dtype=np.float64)
+    wvel = uvel = vvel = np.array([])  # this microphysics test doesn't need winds
+
     thermo_init = Thermodynamics(
-        temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
+        temp,
+        rho,
+        press,
+        qvap,
+        qcond,
+        qice,
+        qrain,
+        qsnow,
+        qgrau,
+        wvel,
+        uvel,
+        vvel,
     )
 
     ### microphysics scheme to use (within a wrapper)

--- a/tests/test_case_1dkid/test_cleo_sdm_condevap_only.py
+++ b/tests/test_case_1dkid/test_cleo_sdm_condevap_only.py
@@ -15,6 +15,7 @@ License: BSD 3-Clause "New" or "Revised" License
 https://opensource.org/licenses/BSD-3-Clause
 -----
 File Description:
+1-D kid test case for CLEO SDM with only condensation/evaporation enabled
 """
 
 import pytest
@@ -30,12 +31,12 @@ def path2pycleo(pytestconfig):
 
 @pytest.fixture(scope="module")
 def config_filename(pytestconfig):
-    return pytestconfig.getoption("cleo_test_1dkid_config_filename")
+    return pytestconfig.getoption("cleo_test_1dkid_condevap_only_config_filename")
 
 
-def test_cleo_sdm_1dkid(path2pycleo, config_filename):
+def test_cleo_sdm_1dkid_condevap_only(path2pycleo, config_filename):
     """runs test of 1-D KiD rainshaft model using CLEO SDM for the
-    microphysics scheme.
+    microphysics scheme with only condensation/evaporation enabled.
 
      NOTE: test assumes CLEO's initial condition binary files already exist
     (i.e. 'dimlessGBxboundaries.dat' and 'dimlessSDsinit.dat' files, whose
@@ -54,7 +55,7 @@ def test_cleo_sdm_1dkid(path2pycleo, config_filename):
     from libs.cleo_sdm.microphysics_scheme_wrapper import MicrophysicsSchemeWrapper
 
     ### label for test case to name data/plots with
-    run_name = "cleo_sdm_1dkid"
+    run_name = "cleo_sdm_1dkid_condevap_only"
 
     ### path to directory to save data/plots in after model run
     binpath = Path(__file__).parent.resolve() / "bin"  # i.e. [current directory]/bin/

--- a/tests/test_case_1dkid/test_cleo_sdm_condevap_only.py
+++ b/tests/test_case_1dkid/test_cleo_sdm_condevap_only.py
@@ -76,7 +76,7 @@ def test_cleo_sdm_1dkid_condevap_only(path2pycleo, config_filename):
     )
 
     ### microphysics scheme to use (within a wrapper)
-    is_motion = True
+    is_motion = False
     microphys_scheme = MicrophysicsSchemeWrapper(
         config_filename,
         is_motion,

--- a/tests/test_case_1dkid/test_cleo_sdm_condevap_only.py
+++ b/tests/test_case_1dkid/test_cleo_sdm_condevap_only.py
@@ -72,15 +72,24 @@ def test_cleo_sdm_1dkid_condevap_only(path2pycleo, config_filename):
     assert z_max % z_delta == 0, "z limit is not a multiple of the grid spacing."
     ngbxs = int(z_max / z_delta)
     zeros = np.zeros(ngbxs)
+    zeros2 = np.tile(zeros, 2)
     thermo_init = Thermodynamics(
-        zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros2,
+        zeros2,
+        zeros2,
     )
-    wvel = np.zeros(ngbxs * 2)
-    uvel = np.zeros(ngbxs * 2)
-    vvel = np.zeros(ngbxs * 2)
 
     ### microphysics scheme to use (within a wrapper)
-    is_motion = False
+    is_motion = True
     microphys_scheme = MicrophysicsSchemeWrapper(
         config_filename,
         is_motion,
@@ -90,9 +99,9 @@ def test_cleo_sdm_1dkid_condevap_only(path2pycleo, config_filename):
         thermo_init.temp,
         thermo_init.massmix_ratios["qvap"],
         thermo_init.massmix_ratios["qcond"],
-        wvel,
-        uvel,
-        vvel,
+        thermo_init.wvel,
+        thermo_init.uvel,
+        thermo_init.vvel,
     )
 
     ### Perform test of 1-D KiD rainshaft model using chosen setup

--- a/tests/test_case_1dkid/test_cleo_sdm_condevap_only.py
+++ b/tests/test_case_1dkid/test_cleo_sdm_condevap_only.py
@@ -89,6 +89,7 @@ def test_cleo_sdm_1dkid_condevap_only(path2pycleo, config_filename):
     )
 
     ### Perform test of 1-D KiD rainshaft model using chosen setup
+    advect_hydrometeors = False
     perform_1dkid_test_case(
         z_delta,
         z_max,
@@ -96,6 +97,7 @@ def test_cleo_sdm_1dkid_condevap_only(path2pycleo, config_filename):
         timestep,
         thermo_init,
         microphys_scheme,
+        advect_hydrometeors,
         binpath,
         run_name,
     )

--- a/tests/test_case_1dkid/test_cleo_sdm_condevap_only.py
+++ b/tests/test_case_1dkid/test_cleo_sdm_condevap_only.py
@@ -70,10 +70,14 @@ def test_cleo_sdm_1dkid_condevap_only(path2pycleo, config_filename):
 
     ### initial thermodynamic conditions
     assert z_max % z_delta == 0, "z limit is not a multiple of the grid spacing."
-    zeros = np.zeros(int(z_max / z_delta))
+    ngbxs = int(z_max / z_delta)
+    zeros = np.zeros(ngbxs)
     thermo_init = Thermodynamics(
         zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros
     )
+    wvel = np.zeros(ngbxs * 2)
+    uvel = np.zeros(ngbxs * 2)
+    vvel = np.zeros(ngbxs * 2)
 
     ### microphysics scheme to use (within a wrapper)
     is_motion = False
@@ -86,6 +90,9 @@ def test_cleo_sdm_1dkid_condevap_only(path2pycleo, config_filename):
         thermo_init.temp,
         thermo_init.massmix_ratios["qvap"],
         thermo_init.massmix_ratios["qcond"],
+        wvel,
+        uvel,
+        vvel,
     )
 
     ### Perform test of 1-D KiD rainshaft model using chosen setup

--- a/tests/test_case_1dkid/test_cleo_sdm_fullscheme.py
+++ b/tests/test_case_1dkid/test_cleo_sdm_fullscheme.py
@@ -91,7 +91,7 @@ def test_cleo_sdm_1dkid_fullscheme(path2pycleo, config_filename):
     )
 
     ### microphysics scheme to use (within a wrapper)
-    is_motion = False
+    is_motion = True
     microphys_scheme = MicrophysicsSchemeWrapper(
         config_filename,
         is_motion,

--- a/tests/test_case_1dkid/test_cleo_sdm_fullscheme.py
+++ b/tests/test_case_1dkid/test_cleo_sdm_fullscheme.py
@@ -91,6 +91,7 @@ def test_cleo_sdm_1dkid_fullscheme(path2pycleo, config_filename):
     )
 
     ### Perform test of 1-D KiD rainshaft model using chosen setup
+    advect_hydrometeors = False
     perform_1dkid_test_case(
         z_delta,
         z_max,
@@ -98,6 +99,7 @@ def test_cleo_sdm_1dkid_fullscheme(path2pycleo, config_filename):
         timestep,
         thermo_init,
         microphys_scheme,
+        advect_hydrometeors,
         binpath,
         run_name,
     )

--- a/tests/test_case_1dkid/test_cleo_sdm_fullscheme.py
+++ b/tests/test_case_1dkid/test_cleo_sdm_fullscheme.py
@@ -74,15 +74,24 @@ def test_cleo_sdm_1dkid_fullscheme(path2pycleo, config_filename):
     assert z_max % z_delta == 0, "z limit is not a multiple of the grid spacing."
     ngbxs = int(z_max / z_delta)
     zeros = np.zeros(ngbxs)
+    zeros2 = np.tile(zeros, 2)
     thermo_init = Thermodynamics(
-        zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros2,
+        zeros2,
+        zeros2,
     )
-    wvel = np.zeros(ngbxs * 2)
-    uvel = np.zeros(ngbxs * 2)
-    vvel = np.zeros(ngbxs * 2)
 
     ### microphysics scheme to use (within a wrapper)
-    is_motion = True
+    is_motion = False
     microphys_scheme = MicrophysicsSchemeWrapper(
         config_filename,
         is_motion,
@@ -92,9 +101,9 @@ def test_cleo_sdm_1dkid_fullscheme(path2pycleo, config_filename):
         thermo_init.temp,
         thermo_init.massmix_ratios["qvap"],
         thermo_init.massmix_ratios["qcond"],
-        wvel,
-        uvel,
-        vvel,
+        thermo_init.wvel,
+        thermo_init.uvel,
+        thermo_init.vvel,
     )
 
     ### Perform test of 1-D KiD rainshaft model using chosen setup

--- a/tests/test_case_1dkid/test_cleo_sdm_fullscheme.py
+++ b/tests/test_case_1dkid/test_cleo_sdm_fullscheme.py
@@ -1,0 +1,103 @@
+"""
+Copyright (c) 2024 MPI-M, Clara Bayley
+
+----- Microphysics Test Cases -----
+File: test_cleo_sdm.py
+Project: test_case_1dkid
+Created Date: Friday 27th June 2025
+Author: Clara Bayley (CB)
+Additional Contributors:
+-----
+Last Modified: Tuesday 1st July 2025
+Modified By: CB
+-----
+License: BSD 3-Clause "New" or "Revised" License
+https://opensource.org/licenses/BSD-3-Clause
+-----
+File Description:
+1-D kid test case for CLEO SDM with full scheme, i.e. with condensation/evaporation,
+collision-coalescence and precipitation enabled
+"""
+
+import pytest
+import numpy as np
+from pathlib import Path
+from PyMPDATA_examples.Shipway_and_Hill_2012 import si
+
+
+@pytest.fixture(scope="module")
+def path2pycleo(pytestconfig):
+    return pytestconfig.getoption("cleo_path2pycleo")
+
+
+@pytest.fixture(scope="module")
+def config_filename(pytestconfig):
+    return pytestconfig.getoption("cleo_test_1dkid_fullscheme_config_filename")
+
+
+def test_cleo_sdm_1dkid_fullscheme(path2pycleo, config_filename):
+    """runs test of 1-D KiD rainshaft model using CLEO SDM for the
+    microphysics scheme with full warm-rain microphysics enabled: condensation/evaporation,
+    collision-coalescence and precipitation (i.e. condensates have terminal velocity).
+
+     NOTE: test assumes CLEO's initial condition binary files already exist
+    (i.e. 'dimlessGBxboundaries.dat' and 'dimlessSDsinit.dat' files, whose
+    locations are given in CLEO's config file ('config_filename')
+
+    This function sets up initial conditions and parameters for running a 1-D KiD rainshaft
+    test case using the CLEO SDM microphysics scheme (via a wrapper).
+    It then runs the test case as specified.
+    """
+    import os
+
+    os.environ["PYCLEO_DIR"] = str(path2pycleo)
+
+    from libs.test_case_1dkid.perform_1dkid_test_case import perform_1dkid_test_case
+    from libs.thermo.thermodynamics import Thermodynamics
+    from libs.cleo_sdm.microphysics_scheme_wrapper import MicrophysicsSchemeWrapper
+
+    ### label for test case to name data/plots with
+    run_name = "cleo_sdm_1dkid_fullscheme"
+
+    ### path to directory to save data/plots in after model run
+    binpath = Path(__file__).parent.resolve() / "bin"  # i.e. [current directory]/bin/
+    binpath.mkdir(parents=False, exist_ok=True)
+
+    ### time and grid parameters
+    # NOTE: these must be consistent with CLEO initial condition binary files(!)
+    z_delta = 25 * si.m  # (!) must be consistent with CLEO
+    z_max = 3200 * si.m  # (!) must be consistent with CLEO
+    timestep = 1.25 * si.s
+    time_end = 15 * si.minutes
+
+    ### initial thermodynamic conditions
+    assert z_max % z_delta == 0, "z limit is not a multiple of the grid spacing."
+    zeros = np.zeros(int(z_max / z_delta))
+    thermo_init = Thermodynamics(
+        zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros
+    )
+
+    ### microphysics scheme to use (within a wrapper)
+    is_motion = True
+    microphys_scheme = MicrophysicsSchemeWrapper(
+        config_filename,
+        is_motion,
+        0.0,
+        timestep,
+        thermo_init.press,
+        thermo_init.temp,
+        thermo_init.massmix_ratios["qvap"],
+        thermo_init.massmix_ratios["qcond"],
+    )
+
+    ### Perform test of 1-D KiD rainshaft model using chosen setup
+    perform_1dkid_test_case(
+        z_delta,
+        z_max,
+        time_end,
+        timestep,
+        thermo_init,
+        microphys_scheme,
+        binpath,
+        run_name,
+    )

--- a/tests/test_case_1dkid/test_cleo_sdm_fullscheme.py
+++ b/tests/test_case_1dkid/test_cleo_sdm_fullscheme.py
@@ -72,10 +72,14 @@ def test_cleo_sdm_1dkid_fullscheme(path2pycleo, config_filename):
 
     ### initial thermodynamic conditions
     assert z_max % z_delta == 0, "z limit is not a multiple of the grid spacing."
-    zeros = np.zeros(int(z_max / z_delta))
+    ngbxs = int(z_max / z_delta)
+    zeros = np.zeros(ngbxs)
     thermo_init = Thermodynamics(
         zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros
     )
+    wvel = np.zeros(ngbxs * 2)
+    uvel = np.zeros(ngbxs * 2)
+    vvel = np.zeros(ngbxs * 2)
 
     ### microphysics scheme to use (within a wrapper)
     is_motion = True
@@ -88,6 +92,9 @@ def test_cleo_sdm_1dkid_fullscheme(path2pycleo, config_filename):
         thermo_init.temp,
         thermo_init.massmix_ratios["qvap"],
         thermo_init.massmix_ratios["qcond"],
+        wvel,
+        uvel,
+        vvel,
     )
 
     ### Perform test of 1-D KiD rainshaft model using chosen setup

--- a/tests/test_case_1dkid/test_icon_muphys.py
+++ b/tests/test_case_1dkid/test_icon_muphys.py
@@ -87,6 +87,7 @@ def test_icon_muphys_1dkid(aes_muphys_py_dir):
         microphys_scheme = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc, lrain)
 
         ### Perform test of 1-D KiD rainshaft model using chosen setup
+        advect_hydrometeors = True
         perform_1dkid_test_case(
             z_delta,
             z_max,
@@ -94,6 +95,7 @@ def test_icon_muphys_1dkid(aes_muphys_py_dir):
             timestep,
             thermo_init,
             microphys_scheme,
+            advect_hydrometeors,
             binpath,
             run_name,
         )

--- a/tests/test_case_1dkid/test_icon_muphys.py
+++ b/tests/test_case_1dkid/test_icon_muphys.py
@@ -73,8 +73,20 @@ def test_icon_muphys_1dkid(aes_muphys_py_dir):
         ### initial thermodynamic conditions
         assert z_max % z_delta == 0, "z limit is not a multiple of the grid spacing."
         zeros = np.zeros(int(z_max / z_delta))
+        null = np.array([])  # this microphysics test doesn't need winds
         thermo_init = Thermodynamics(
-            zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros
+            zeros,
+            zeros,
+            zeros,
+            zeros,
+            zeros,
+            zeros,
+            zeros,
+            zeros,
+            zeros,
+            null,
+            null,
+            null,
         )
 
         ### microphysics scheme to use (within a wrapper)

--- a/tests/test_case_1dkid/test_icon_satadj.py
+++ b/tests/test_case_1dkid/test_icon_satadj.py
@@ -73,8 +73,20 @@ def test_icon_satadj_scheme_1dkid(aes_muphys_py_dir):
         ### initial thermodynamic conditions
         assert z_max % z_delta == 0, "z limit is not a multiple of the grid spacing."
         zeros = np.zeros(int(z_max / z_delta))
+        null = np.array([])  # this microphysics test doesn't need winds
         thermo_init = Thermodynamics(
-            zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros
+            zeros,
+            zeros,
+            zeros,
+            zeros,
+            zeros,
+            zeros,
+            zeros,
+            zeros,
+            zeros,
+            null,
+            null,
+            null,
         )
 
         ### microphysics scheme to use (within a wrapper)

--- a/tests/test_case_1dkid/test_icon_satadj.py
+++ b/tests/test_case_1dkid/test_icon_satadj.py
@@ -86,6 +86,7 @@ def test_icon_satadj_scheme_1dkid(aes_muphys_py_dir):
         microphys_scheme = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 
         ### Perform test of 1-D KiD rainshaft model using chosen setup
+        advect_hydrometeors = True
         perform_1dkid_test_case(
             z_delta,
             z_max,
@@ -93,6 +94,7 @@ def test_icon_satadj_scheme_1dkid(aes_muphys_py_dir):
             timestep,
             thermo_init,
             microphys_scheme,
+            advect_hydrometeors,
             binpath,
             run_name,
         )

--- a/tests/test_case_1dkid/test_pympdata_bulk.py
+++ b/tests/test_case_1dkid/test_pympdata_bulk.py
@@ -60,6 +60,7 @@ def test_pympdata_bulk_scheme_1dkid():
     microphys_scheme = MicrophysicsSchemeWrapper()
 
     ### Perform test of 1-D KiD rainshaft model using chosen setup
+    advect_hydrometeors = True
     perform_1dkid_test_case(
         z_delta,
         z_max,
@@ -67,6 +68,7 @@ def test_pympdata_bulk_scheme_1dkid():
         timestep,
         thermo_init,
         microphys_scheme,
+        advect_hydrometeors,
         binpath,
         run_name,
     )

--- a/tests/test_case_1dkid/test_pympdata_bulk.py
+++ b/tests/test_case_1dkid/test_pympdata_bulk.py
@@ -52,8 +52,20 @@ def test_pympdata_bulk_scheme_1dkid():
     ### initial thermodynamic conditions
     assert z_max % z_delta == 0, "z limit is not a multiple of the grid spacing."
     zeros = np.zeros(int(z_max / z_delta))
+    null = np.array([])  # this microphysics test doesn't need winds
     thermo_init = Thermodynamics(
-        zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros, zeros
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        null,
+        null,
+        null,
     )
 
     ### microphysics scheme to use (within a wrapper)

--- a/tests/test_cleo_sdm_microphysics_scheme.py
+++ b/tests/test_cleo_sdm_microphysics_scheme.py
@@ -58,14 +58,22 @@ def test_initialize(path2pycleo, config_filename):
     t_start = 0
     timestep = python_config["timesteps"]["COUPLTSTEP"]  # [s]
     is_motion = python_config["pycleo_settings"]["is_motion"]
-    press = np.array([], dtype=np.float64)
-    temp = np.array([], dtype=np.float64)
-    qvap = np.array([], dtype=np.float64)
-    qcond = np.array([], dtype=np.float64)
+    arr = np.array([], dtype=np.float64)
+    press = temp = qvap = qcond = wvel = uvel = vvel = arr
     config = pycleo.Config(str(config_filename))
     pycleo.pycleo_initialize(config)
     microphys = MicrophysicsScheme(
-        config, is_motion, t_start, timestep, press, temp, qvap, qcond
+        config,
+        is_motion,
+        t_start,
+        timestep,
+        press,
+        temp,
+        qvap,
+        qcond,
+        wvel,
+        uvel,
+        vvel,
     )
 
     assert microphys.name == "CLEO SDM microphysics"
@@ -85,10 +93,8 @@ def test_initialize_wrapper(path2pycleo, config_filename):
     t_start = 0
     timestep = python_config["timesteps"]["COUPLTSTEP"]  # [s]
     is_motion = python_config["pycleo_settings"]["is_motion"]
-    press = np.array([], dtype=np.float64)
-    temp = np.array([], dtype=np.float64)
-    qvap = np.array([], dtype=np.float64)
-    qcond = np.array([], dtype=np.float64)
+    arr = np.array([], dtype=np.float64)
+    press = temp = qvap = qcond = wvel = uvel = vvel = arr
     microphys_wrapped = MicrophysicsSchemeWrapper(
         config_filename,
         is_motion,
@@ -98,6 +104,9 @@ def test_initialize_wrapper(path2pycleo, config_filename):
         temp,
         qvap,
         qcond,
+        wvel,
+        uvel,
+        vvel,
     )
 
     assert microphys_wrapped.initialize() == 0
@@ -117,10 +126,8 @@ def test_finalize_wrapper(path2pycleo, config_filename):
     t_start = 0
     timestep = python_config["timesteps"]["COUPLTSTEP"]  # [s]
     is_motion = python_config["pycleo_settings"]["is_motion"]
-    press = np.array([], dtype=np.float64)
-    temp = np.array([], dtype=np.float64)
-    qvap = np.array([], dtype=np.float64)
-    qcond = np.array([], dtype=np.float64)
+    arr = np.array([], dtype=np.float64)
+    press = temp = qvap = qcond = wvel = uvel = vvel = arr
     microphys_wrapped = MicrophysicsSchemeWrapper(
         config_filename,
         is_motion,
@@ -130,6 +137,9 @@ def test_finalize_wrapper(path2pycleo, config_filename):
         temp,
         qvap,
         qcond,
+        wvel,
+        uvel,
+        vvel,
     )
 
     assert microphys_wrapped.finalize() == 0
@@ -152,19 +162,23 @@ def test_microphys_with_wrapper(path2pycleo, config_filename):
     t_start = 0
     timestep = python_config["timesteps"]["COUPLTSTEP"]  # [s]
     is_motion = python_config["pycleo_settings"]["is_motion"]
-    temp1 = np.array([288.15], dtype=np.float64)
-    temp2 = np.array([288.15], dtype=np.float64)
-    rho = np.array([1.225], dtype=np.float64)
-    press1 = np.array([101325], dtype=np.float64)
-    press2 = np.array([101325], dtype=np.float64)
-    qvap1 = np.array([0.015], dtype=np.float64)
-    qvap2 = np.array([0.015], dtype=np.float64)
-    qcond1 = np.array([0.0001], dtype=np.float64)
-    qcond2 = np.array([0.0001], dtype=np.float64)
-    qice = np.array([0.0002], dtype=np.float64)
-    qrain = np.array([0.0003], dtype=np.float64)
-    qsnow = np.array([0.0004], dtype=np.float64)
-    qgrau = np.array([0.0005], dtype=np.float64)
+    ngbxs = python_config["domain"]["ngbxs"]
+    temp1 = np.tile(np.array([288.15], dtype=np.float64), ngbxs)
+    temp2 = np.tile(np.array([288.15], dtype=np.float64), ngbxs)
+    press1 = np.tile(np.array([101325], dtype=np.float64), ngbxs)
+    press2 = np.tile(np.array([101325], dtype=np.float64), ngbxs)
+    qvap1 = np.tile(np.array([0.015], dtype=np.float64), ngbxs)
+    qvap2 = np.tile(np.array([0.015], dtype=np.float64), ngbxs)
+    qcond1 = np.tile(np.array([0.0001], dtype=np.float64), ngbxs)
+    qcond2 = np.tile(np.array([0.0001], dtype=np.float64), ngbxs)
+    rho = np.tile(np.array([1.225], dtype=np.float64), ngbxs)
+    qice = np.tile(np.array([0.0002], dtype=np.float64), ngbxs)
+    qrain = np.tile(np.array([0.0003], dtype=np.float64), ngbxs)
+    qsnow = np.tile(np.array([0.0004], dtype=np.float64), ngbxs)
+    qgrau = np.tile(np.array([0.0005], dtype=np.float64), ngbxs)
+    wvel = np.tile(np.array([-1.2, 1.0], dtype=np.float64), ngbxs)
+    uvel = np.tile(np.array([-0.1, 0.2], dtype=np.float64), ngbxs)
+    vvel = np.tile(np.array([0.0, 0.0], dtype=np.float64), ngbxs)
 
     thermo1 = Thermodynamics(
         temp1, rho, press1, qvap1, qcond1, qice, qrain, qsnow, qgrau
@@ -175,7 +189,17 @@ def test_microphys_with_wrapper(path2pycleo, config_filename):
 
     config = pycleo.Config(str(config_filename))
     microphys = MicrophysicsScheme(
-        config, is_motion, t_start, timestep, press1, temp1, qvap1, qcond1
+        config,
+        is_motion,
+        t_start,
+        timestep,
+        press1,
+        temp1,
+        qvap1,
+        qcond1,
+        wvel,
+        uvel,
+        vvel,
     )
 
     microphys_wrapped = MicrophysicsSchemeWrapper(
@@ -187,12 +211,15 @@ def test_microphys_with_wrapper(path2pycleo, config_filename):
         temp2,
         qvap2,
         qcond2,
+        wvel,
+        uvel,
+        vvel,
     )
 
     microphys.run(timestep)  # implict change of thermo1
     thermo2 = microphys_wrapped.run(timestep, thermo2)
 
-    assert thermo1.press == thermo2.press
-    assert thermo1.temp == thermo2.temp
+    assert np.all(thermo1.press == thermo2.press)
+    assert np.all(thermo1.temp == thermo2.temp)
     for q1, q2 in zip(thermo1.unpack_massmix_ratios(), thermo2.unpack_massmix_ratios()):
-        assert q1 == q2
+        assert np.all(q1 == q2)

--- a/tests/test_cleo_sdm_microphysics_scheme.py
+++ b/tests/test_cleo_sdm_microphysics_scheme.py
@@ -181,10 +181,32 @@ def test_microphys_with_wrapper(path2pycleo, config_filename):
     vvel = np.tile(np.array([0.0, 0.0], dtype=np.float64), ngbxs)
 
     thermo1 = Thermodynamics(
-        temp1, rho, press1, qvap1, qcond1, qice, qrain, qsnow, qgrau
+        temp1,
+        rho,
+        press1,
+        qvap1,
+        qcond1,
+        qice,
+        qrain,
+        qsnow,
+        qgrau,
+        wvel,
+        uvel,
+        vvel,
     )
     thermo2 = Thermodynamics(
-        temp2, rho, press2, qvap2, qcond2, qice, qrain, qsnow, qgrau
+        temp2,
+        rho,
+        press2,
+        qvap2,
+        qcond2,
+        qice,
+        qrain,
+        qsnow,
+        qgrau,
+        wvel,
+        uvel,
+        vvel,
     )
 
     config = pycleo.Config(str(config_filename))
@@ -193,13 +215,13 @@ def test_microphys_with_wrapper(path2pycleo, config_filename):
         is_motion,
         t_start,
         timestep,
-        press1,
-        temp1,
-        qvap1,
-        qcond1,
-        wvel,
-        uvel,
-        vvel,
+        thermo1.press,
+        thermo1.temp,
+        thermo1.massmix_ratios["qvap"],
+        thermo1.massmix_ratios["qcond"],
+        thermo1.wvel,
+        thermo1.uvel,
+        thermo1.vvel,
     )
 
     microphys_wrapped = MicrophysicsSchemeWrapper(
@@ -207,13 +229,13 @@ def test_microphys_with_wrapper(path2pycleo, config_filename):
         is_motion,
         t_start,
         timestep,
-        press2,
-        temp2,
-        qvap2,
-        qcond2,
-        wvel,
-        uvel,
-        vvel,
+        thermo2.press,
+        thermo2.temp,
+        thermo2.massmix_ratios["qvap"],
+        thermo2.massmix_ratios["qcond"],
+        thermo2.wvel,
+        thermo2.uvel,
+        thermo2.vvel,
     )
 
     microphys.run(timestep)  # implict change of thermo1

--- a/tests/test_cleo_sdm_microphysics_scheme.py
+++ b/tests/test_cleo_sdm_microphysics_scheme.py
@@ -57,7 +57,7 @@ def test_initialize(path2pycleo, config_filename):
 
     t_start = 0
     timestep = python_config["timesteps"]["COUPLTSTEP"]  # [s]
-    is_motion = python_config["pycleo_settings"]["is_motion"]
+    is_motion = python_config["pycleo_setup"]["is_motion"]
     arr = np.array([], dtype=np.float64)
     press = temp = qvap = qcond = wvel = uvel = vvel = arr
     config = pycleo.Config(str(config_filename))
@@ -92,7 +92,7 @@ def test_initialize_wrapper(path2pycleo, config_filename):
 
     t_start = 0
     timestep = python_config["timesteps"]["COUPLTSTEP"]  # [s]
-    is_motion = python_config["pycleo_settings"]["is_motion"]
+    is_motion = python_config["pycleo_setup"]["is_motion"]
     arr = np.array([], dtype=np.float64)
     press = temp = qvap = qcond = wvel = uvel = vvel = arr
     microphys_wrapped = MicrophysicsSchemeWrapper(
@@ -125,7 +125,7 @@ def test_finalize_wrapper(path2pycleo, config_filename):
 
     t_start = 0
     timestep = python_config["timesteps"]["COUPLTSTEP"]  # [s]
-    is_motion = python_config["pycleo_settings"]["is_motion"]
+    is_motion = python_config["pycleo_setup"]["is_motion"]
     arr = np.array([], dtype=np.float64)
     press = temp = qvap = qcond = wvel = uvel = vvel = arr
     microphys_wrapped = MicrophysicsSchemeWrapper(
@@ -161,7 +161,7 @@ def test_microphys_with_wrapper(path2pycleo, config_filename):
 
     t_start = 0
     timestep = python_config["timesteps"]["COUPLTSTEP"]  # [s]
-    is_motion = python_config["pycleo_settings"]["is_motion"]
+    is_motion = python_config["pycleo_setup"]["is_motion"]
     ngbxs = python_config["domain"]["ngbxs"]
     temp1 = np.tile(np.array([288.15], dtype=np.float64), ngbxs)
     temp2 = np.tile(np.array([288.15], dtype=np.float64), ngbxs)

--- a/tests/test_icon_muphys_microphysics_scheme.py
+++ b/tests/test_icon_muphys_microphysics_scheme.py
@@ -69,9 +69,21 @@ def test_microphys_with_wrapper(aes_muphys_py_dir):
         qrain = np.array([0.0003], dtype=np.float64)
         qsnow = np.array([0.0004], dtype=np.float64)
         qgrau = np.array([0.0005], dtype=np.float64)
+        wvel = uvel = vvel = np.array([])  # this microphysics test doesn't need winds
 
         thermo = Thermodynamics(
-            temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
+            temp,
+            rho,
+            press,
+            qvap,
+            qcond,
+            qice,
+            qrain,
+            qsnow,
+            qgrau,
+            wvel,
+            uvel,
+            vvel,
         )
 
         prr_gsp = np.zeros(nvec, np.float64)

--- a/tests/test_icon_satadj_microphysics_scheme.py
+++ b/tests/test_icon_satadj_microphysics_scheme.py
@@ -101,9 +101,21 @@ def test_microphys_with_wrapper(aes_muphys_py_dir):
         qrain = np.array([0.0003], dtype=np.float64)
         qsnow = np.array([0.0004], dtype=np.float64)
         qgrau = np.array([0.0005], dtype=np.float64)
+        wvel = uvel = vvel = np.array([])  # this microphysics test doesn't need winds
 
         thermo = Thermodynamics(
-            temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau
+            temp,
+            rho,
+            press,
+            qvap,
+            qcond,
+            qice,
+            qrain,
+            qsnow,
+            qgrau,
+            wvel,
+            uvel,
+            vvel,
         )
 
         # call saturation adjustment

--- a/tests/test_mock_microphys_microphysics_scheme.py
+++ b/tests/test_mock_microphys_microphysics_scheme.py
@@ -79,8 +79,22 @@ def test_microphys_with_wrapper():
     qrain = np.array([0.0003], dtype=np.float64)
     qsnow = np.array([0.0004], dtype=np.float64)
     qgrau = np.array([0.0005], dtype=np.float64)
+    wvel = uvel = vvel = np.array([])  # this microphysics test doesn't need winds
 
-    thermo = Thermodynamics(temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau)
+    thermo = Thermodynamics(
+        temp,
+        rho,
+        press,
+        qvap,
+        qcond,
+        qice,
+        qrain,
+        qsnow,
+        qgrau,
+        wvel,
+        uvel,
+        vvel,
+    )
 
     t, qv, qc, qi, qr, qs, qg, prr_gsp, pflx = microphys.run(
         nvec,

--- a/tests/test_pympdata_bulk_microphysics_scheme.py
+++ b/tests/test_pympdata_bulk_microphysics_scheme.py
@@ -67,8 +67,22 @@ def test_microphys_with_wrapper():
     qrain = np.array([0.0003], dtype=np.float64)
     qsnow = np.array([0.0004], dtype=np.float64)
     qgrau = np.array([0.0005], dtype=np.float64)
+    wvel = uvel = vvel = np.array([])  # this microphysics test doesn't need winds
 
-    thermo = Thermodynamics(temp, rho, press, qvap, qcond, qice, qrain, qsnow, qgrau)
+    thermo = Thermodynamics(
+        temp,
+        rho,
+        press,
+        qvap,
+        qcond,
+        qice,
+        qrain,
+        qsnow,
+        qgrau,
+        wvel,
+        uvel,
+        vvel,
+    )
 
     qv, qc = bulk_scheme_condensation(temp, press, qvap, qcond)
 


### PR DESCRIPTION
## Key point
Two tests for CLEO SDM in 1-D KiD setup:
1) KiD test for condensation/evaporation only
2) KiD test for full scheme: condensation/evaporation, collision-coalescence and precipitation

## Required new features:
- option not to advect hydrometeors (qcond) via KiD dynamics driver
- higher CLEO version >= 0.49.0
