### PR TITLE
fix testcase 1-D KiD for ICON muphys

### DIFF
--- a/libs/icon_muphys/microphysics_scheme_wrapper.py
+++ b/libs/icon_muphys/microphysics_scheme_wrapper.py
@@ -24,7 +24,6 @@ export AES_MUPHYS_PY_DIR=/work/k20200/k202174/icon-mpim/ragnarok/build_py/src/ae
 import os
 import sys
 import numpy as np
-from copy import deepcopy
 
 from ..thermo.thermodynamics import Thermodynamics
 
@@ -129,6 +128,9 @@ class MicrophysicsSchemeWrapper:
         This method is a wrapper of the MicrophysicsScheme object's run function to call the
         microphysics computations in a way that's compatible with the test and scripts in this project.
 
+        _NOTE!_ flip(...) (and copy) operations performed because ICON 'z' dimension is upside-down
+        (0th index is top of atmosphere). Operation only works for 1-D or 0-D tests.
+
         Args:
             timestep (float):
               Time-step for integration of microphysics (s)
@@ -140,12 +142,13 @@ class MicrophysicsSchemeWrapper:
 
         """
 
-        cp_thermo = deepcopy(thermo)
         dt = np.float64(timestep)
-        t = cp_thermo.temp
-        rho = cp_thermo.rho
-        p = cp_thermo.press
-        qv, qc, qi, qr, qs, qg = cp_thermo.unpack_massmix_ratios()
+        t = np.copy(np.flip(thermo.temp))
+        rho = np.copy(np.flip(thermo.rho))
+        p = np.copy(np.flip(thermo.press))
+        qv, qc, qi, qr, qs, qg = [
+            np.copy(np.flip(x)) for x in thermo.unpack_massmix_ratios()
+        ]
 
         prr_gsp = np.zeros(self.nvec, dtype=np.float64)
         pri_gsp = np.zeros(self.nvec, dtype=np.float64)
@@ -205,7 +208,10 @@ class MicrophysicsSchemeWrapper:
             rho=rho,
         )
 
-        cp_thermo.temp[:] = t
-        cp_thermo.copy_massmix_ratios(qv, qc, qi, qr, qs, qg)
+        thermo.temp[:] = np.flip(t)
+        thermo.rho[:] = np.flip(rho)
+        thermo.press[:] = np.flip(p)
+        massmix_ratios = [np.flip(x) for x in [qv, qc, qi, qr, qs, qg]]
+        thermo.copy_massmix_ratios(*massmix_ratios)
 
-        return cp_thermo
+        return thermo

--- a/libs/icon_satadj/microphysics_scheme_wrapper.py
+++ b/libs/icon_satadj/microphysics_scheme_wrapper.py
@@ -23,7 +23,7 @@ export AES_MUPHYS_PY_DIR=/work/k20200/k202174/icon-mpim/ragnarok/build_py/src/ae
 
 import os
 import sys
-from copy import deepcopy
+import numpy as np
 
 from ..thermo.thermodynamics import Thermodynamics
 
@@ -126,6 +126,9 @@ class MicrophysicsSchemeWrapper:
         This method is a wrapper of the MicrophysicsScheme object's run function to call the
         microphysics computations in a way that's compatible with the test and scripts in this project.
 
+        _NOTE!_ flip(...) (and copy) operations performed because ICON 'z' dimension is upside-down
+        (0th index is top of atmosphere). Operation only works for 1-D or 0-D tests.
+
         Args:
             timestep (float):
               Time-step for integration of microphysics (s)
@@ -137,10 +140,11 @@ class MicrophysicsSchemeWrapper:
 
         """
 
-        cp_thermo = deepcopy(thermo)
-        t = cp_thermo.temp
-        rho = cp_thermo.rho
-        qv, qc, qi, qr, qs, qg = cp_thermo.unpack_massmix_ratios()
+        t = np.copy(np.flip(thermo.temp))
+        rho = np.copy(np.flip(thermo.rho))
+        qv, qc, qi, qr, qs, qg = [
+            np.copy(np.flip(x)) for x in thermo.unpack_massmix_ratios()
+        ]
 
         # call saturation adjustment
         total_ice = qg + qs + qi  # temporary variable
@@ -155,7 +159,9 @@ class MicrophysicsSchemeWrapper:
             rho=rho,
         )
 
-        cp_thermo.temp[:] = t
-        cp_thermo.copy_massmix_ratios(qv, qc, qi, qr, qs, qg)
+        thermo.temp[:] = np.flip(t)
+        thermo.rho[:] = np.flip(rho)
+        massmix_ratios = [np.flip(x) for x in [qv, qc, qi, qr, qs, qg]]
+        thermo.copy_massmix_ratios(*massmix_ratios)
 
-        return cp_thermo
+        return thermo

--- a/tests/test_case_1dkid/test_icon_muphys.py
+++ b/tests/test_case_1dkid/test_icon_muphys.py
@@ -93,7 +93,8 @@ def test_icon_muphys_1dkid(aes_muphys_py_dir):
         nvec = 1
         ke = 128
         ivstart = 0
-        dz = np.array([25], dtype=np.float64)
+        dz = np.empty(ke, dtype=np.float64)
+        dz.fill(25)
         qnc = 500
         lrain = True
         microphys_scheme = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc, lrain)

--- a/tests/test_case_1dkid/test_icon_satadj.py
+++ b/tests/test_case_1dkid/test_icon_satadj.py
@@ -93,7 +93,8 @@ def test_icon_satadj_scheme_1dkid(aes_muphys_py_dir):
         nvec = 1
         ke = 128
         ivstart = 0
-        dz = np.array([25], dtype=np.float64)
+        dz = np.empty(ke, dtype=np.float64)
+        dz.fill(25)
         qnc = 500
         microphys_scheme = MicrophysicsSchemeWrapper(nvec, ke, ivstart, dz, qnc)
 


### PR DESCRIPTION
Fix that after a number of steps, the temperature contains `NaN`  because the `dz` was not correctly set.

PR also makes ICON satadj wrapper analogous to fixed ICON muphys wrapper.